### PR TITLE
Remove Extra Build Script Reference and extra flag from Tests.

### DIFF
--- a/EarlGrey.xcodeproj/project.pbxproj
+++ b/EarlGrey.xcodeproj/project.pbxproj
@@ -358,7 +358,6 @@
 		FD6D0B9F1C6D494F0001EA75 /* GREYNot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GREYNot.m; sourceTree = "<group>"; };
 		FD6D0BA01C6D494F0001EA75 /* GREYStringDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GREYStringDescription.h; sourceTree = "<group>"; };
 		FD6D0BA11C6D494F0001EA75 /* GREYStringDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GREYStringDescription.m; sourceTree = "<group>"; };
-		FDA41E101C602D43008DEE88 /* build_universal_static_framework.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = build_universal_static_framework.sh; path = Scripts/build_universal_static_framework.sh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -690,14 +689,6 @@
 			name = fishhook;
 			sourceTree = "<group>";
 		};
-		FDA41E0F1C602D2D008DEE88 /* Scripts */ = {
-			isa = PBXGroup;
-			children = (
-				FDA41E101C602D43008DEE88 /* build_universal_static_framework.sh */,
-			);
-			name = Scripts;
-			sourceTree = "<group>";
-		};
 		FDE401021BE83859001C172E /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
@@ -712,7 +703,6 @@
 				FD1000EA1C5B466F00B2DB0A /* EarlGrey */,
 				FD06C6751BECAE6A009032A5 /* Frameworks */,
 				FDE401021BE83859001C172E /* Dependencies */,
-				FDA41E0F1C602D2D008DEE88 /* Scripts */,
 				FDE4FFAA1BE831AA001C172E /* Products */,
 			);
 			sourceTree = "<group>";

--- a/Tests/FunctionalTests/FunctionalTests.xcodeproj/project.pbxproj
+++ b/Tests/FunctionalTests/FunctionalTests.xcodeproj/project.pbxproj
@@ -906,8 +906,6 @@
 					"$(inherited)",
 					"-ObjC",
 					"-framework",
-					OCHamcrest,
-					"-framework",
 					IOKit,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -943,8 +941,6 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
-					"-framework",
-					OCHamcrest,
 					"-framework",
 					IOKit,
 				);

--- a/Tests/UnitTests/Sources/GREYActionsTest.m
+++ b/Tests/UnitTests/Sources/GREYActionsTest.m
@@ -154,7 +154,7 @@
   UIControl *view = [[UIControl alloc] init];
 
   // Mock out [GREYMatchers matcherForSufficientlyVisible] for a matcher that matches anything.
-  id mockMatcher = [OCMockObject mockForProtocol:@protocol(HCMatcher)];
+  id mockMatcher = [OCMockObject mockForProtocol:@protocol(GREYMatcher)];
   OCMStub([mockMatcher matches:OCMOCK_ANY]).andReturn(@YES);
   id mockGREYMatchers = OCMClassMock([GREYMatchers class]);
   OCMStub([mockGREYMatchers matcherForSufficientlyVisible]).andReturn(mockMatcher);

--- a/Tests/UnitTests/Sources/GREYElementMatcherBlockTest.m
+++ b/Tests/UnitTests/Sources/GREYElementMatcherBlockTest.m
@@ -15,7 +15,6 @@
 //
 
 #import <EarlGrey/GREYElementMatcherBlock.h>
-#import <OCHamcrest/HCStringDescription.h>
 
 #import "GREYBaseTest.h"
 

--- a/Tests/UnitTests/UnitTests.xcodeproj/project.pbxproj
+++ b/Tests/UnitTests/UnitTests.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -664,7 +664,7 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -794,8 +794,6 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-framework",
-					OCHamcrest,
-					"-framework",
 					IOKit,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -820,8 +818,6 @@
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
 					"-ObjC",
-					"-framework",
-					OCHamcrest,
 					"-framework",
 					IOKit,
 				);


### PR DESCRIPTION
An extra file - `https://github.com/google/EarlGrey/pull/7` is present in the `EarlGrey.xcodeproj` file, which isn't used and causes project breaks.

Also remove `-framework OCHamcrest` from both Test Projects as per https://github.com/google/EarlGrey/issues/4. Also, since we have a number of non-modular imports in UnitTests, turn `Enable Modules` off to prevent issues with imports.