### PR TITLE
Adding Travis CI badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/google/EarlGrey.svg?branch=master)](https://travis-ci.org/google/EarlGrey)
+
 # EarlGrey
 
 EarlGrey is a native iOS UI automation test framework that enables you to write


### PR DESCRIPTION
Adding Travis CI badge to README and triggering the first Travis CI build after setting it up.