### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: objective-c
+osx_image: xcode7.2
 sudo: false
 env:
   matrix:
     - DESTINATION="OS=9.2,name=iPhone 6s" SDK=iphonesimulator9.2
-    - DESTINATION="OS=9.1,name=iPhone 6s Plus" SDK=iphonesimulator9.2
-    - DESTINATION="OS=9.0,name=iPad Pro" SDK=iphonesimulator9.2
+    - DESTINATION="OS=9.1,name=iPad Pro" SDK=iphonesimulator9.2
+    - DESTINATION="OS=9.0,name=iPhone 6s Plus" SDK=iphonesimulator9.2
     - DESTINATION="OS=8.4,name=iPad 2" SDK=iphonesimulator9.2
     - DESTINATION="OS=8.3,name=iPad Retina" SDK=iphonesimulator9.2
     - DESTINATION="OS=8.2,name=iPad Air" SDK=iphonesimulator9.2
     - DESTINATION="OS=8.1,name=iPhone 5" SDK=iphonesimulator9.2
-    - DESTINATION="OS=8.0,name=iPhone 4S" SDK=iphonesimulator9.2
+    - DESTINATION="OS=8.1,name=iPhone 4S" SDK=iphonesimulator9.2
 
 before_script:
   - Scripts/setup-earlgrey.sh
@@ -17,5 +18,5 @@ install:
   - set -o pipefail
   - xcodebuild -version
   - xcodebuild -showsdks
-  - xcodebuild -project Tests/UnitTests/UnitTests.xcodeproj -scheme EarlGreyUnitTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test
-  - xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test
+  - xcodebuild -project Tests/UnitTests/UnitTests.xcodeproj -scheme EarlGreyUnitTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO clean test
+  - xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO clean test


### PR DESCRIPTION
Adding xcode version to travis yml file in an effort to fix CI. 

The error shown in travis build is:
xcodebuild: error: SDK "iphonesimulator9.2" cannot be located.