### PR TITLE
Fix document about importing library in Swift

### DIFF
--- a/docs/install-and-run.md
+++ b/docs/install-and-run.md
@@ -263,7 +263,7 @@ steps in your setup:
 1. Import EarlGrey in your test bundle's bridging header:
 
    ```
-    @import EarlGrey
+    #import <EarlGrey/EarlGrey.h>
    ```
 
 2. Download [`EarlGrey.swift`](../Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGrey.swift) and add it to your test bundle. The file contains


### PR DESCRIPTION
To import EarlGrey library in Swift, `#import <EarlGrey/EarlGrey.h>` should be written in test bundle's bridging header.