### PR TITLE
Fixing the way test execution was halted on a failure

### DIFF
--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.h
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.h
@@ -89,9 +89,16 @@ UIKIT_EXTERN NSString *const kGREYXCTestCaseNotificationKey;
 - (NSString *)grey_testClassName;
 
 /**
+ *  Interrupts the current test case execution immediately, tears down the test and marks it as
+ *  failed.
+ */
+- (void)grey_interruptExecution;
+
+/**
  *  @return A unique test outputs directory for the current test. All test related outputs should be
  *          under this directory (and subdirectories).
  */
 - (NSString *)grey_localizedTestOutputsDirectory;
 
 @end
+

--- a/EarlGrey/Exception/GREYDefaultFailureHandler.m
+++ b/EarlGrey/Exception/GREYDefaultFailureHandler.m
@@ -111,14 +111,14 @@
   } else {
     failureDescription = [NSString stringWithFormat:@"%@ has occurred.", [exception class]];
   }
+  NSLog(@"%@", exceptionLog);
+
+  [XCTestCase grey_currentTestCase].continueAfterFailure = NO;
   [[XCTestCase grey_currentTestCase] recordFailureWithDescription:failureDescription
                                                            inFile:_fileName
                                                            atLine:_lineNumber
                                                          expected:NO];
-  NSLog(@"%@", exceptionLog);
-
-  // This will cause the current test case to stop executing further.
-  [GREYFrameworkException raise:exception.name format:@"%@", exception.reason];
+  [[XCTestCase grey_currentTestCase] grey_interruptExecution];
 }
 
 #pragma mark - Private
@@ -154,3 +154,4 @@
 }
 
 @end
+


### PR DESCRIPTION
Instead of rethrowing a custom exception, rely on xctest's ability to halt execution of the test case. This results in only one exception being thrown which interrupts the test case and marks it as failed.