### PR TITLE
Fix Ruby shebang

### DIFF
--- a/Demo/EarlGreyExample/configure_earlgrey_pods.rb
+++ b/Demo/EarlGreyExample/configure_earlgrey_pods.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 #
 #  Copyright 2016 Google Inc.
 #

--- a/Scripts/configure_earlgrey_pods.rb
+++ b/Scripts/configure_earlgrey_pods.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 #
 #  Copyright 2016 Google Inc.
 #


### PR DESCRIPTION
/usr/bin/ruby will activate the wrong ruby when using rbenv on a mac.