### PR TITLE
Add Swift Wrapper for GREYAllOf and GREYAnyOf for shorthand compatibility.

### DIFF
--- a/Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGrey.swift
+++ b/Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGrey.swift
@@ -14,8 +14,16 @@
 // limitations under the License.
 //
 
-public func EarlGrey() -> EarlGreyImpl {
+public func EarlGrey() -> EarlGreyImpl! {
   return EarlGreyImpl.invokedFromFile(#file, lineNumber: #line)
+}
+
+func grey_allOfMatchers(args: AnyObject...) -> GREYMatcher! {
+  return GREYAllOf.init(matchers: args)
+}
+
+func grey_anyOfMatchers(args: AnyObject...) -> GREYMatcher! {
+  return GREYAnyOf.init(matchers: args)
 }
 
 public func GREYAssert(@autoclosure expression: () -> BooleanType, reason: String) {

--- a/Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGreyExampleSwiftTests.swift
+++ b/Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGreyExampleSwiftTests.swift
@@ -18,7 +18,7 @@ import XCTest
 @testable import EarlGreyExampleSwift
 
 class EarlGreyExampleSwiftTests: XCTestCase {
-  
+
   func testBasicSelection() {
     // Select the button with Accessibility ID "clickMe".
     EarlGrey().selectElementWithMatcher(grey_accessibilityID("ClickMe"))
@@ -58,7 +58,7 @@ class EarlGreyExampleSwiftTests: XCTestCase {
   func testCollectionMatchers() {
     // First way to disambiguate: use collection matchers.
     let visibleSendButtonMatcher =
-        GREYAllOf.init(matchers: [grey_accessibilityID("ClickMe"), grey_sufficientlyVisible()]);
+        grey_allOfMatchers(grey_accessibilityID("ClickMe"), grey_sufficientlyVisible())
     EarlGrey().selectElementWithMatcher(visibleSendButtonMatcher)
         .performAction(grey_doubleTap())
   }

--- a/Tests/FunctionalTests/Sources/EarlGrey.swift
+++ b/Tests/FunctionalTests/Sources/EarlGrey.swift
@@ -14,7 +14,15 @@
 // limitations under the License.
 //
 
-public func EarlGrey() -> EarlGreyImpl {
+func grey_allOfMatchers(args: AnyObject...) -> GREYMatcher! {
+  return GREYAllOf.init(matchers: args)
+}
+
+func grey_anyOfMatchers(args: AnyObject...) -> GREYMatcher! {
+  return GREYAnyOf.init(matchers: args)
+}
+
+public func EarlGrey() -> EarlGreyImpl! {
   return EarlGreyImpl.invokedFromFile(#file, lineNumber: #line)
 }
 

--- a/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
+++ b/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
@@ -45,10 +45,20 @@ class FunctionalTestRigSwiftTests: XCTestCase {
   func testButtonPressWithGREYAllOf() {
     self.openTestView("Basic Views")
     EarlGrey().selectElementWithMatcher(grey_text("Tab 2")).performAction(grey_tap())
-    let matcher = GREYAllOf.init(matchers: [grey_text("Long Press"),
-                                            grey_sufficientlyVisible()])
+    let matcher = grey_allOfMatchers(grey_text("Long Press"), grey_sufficientlyVisible())
     EarlGrey().selectElementWithMatcher(matcher).performAction(grey_longPressWithDuration(1.0))
         .assertWithMatcher(grey_notVisible())
+  }
+
+  func testPossibleOpeningViews() {
+    self.openTestView("Alert Views")
+    let matcher = grey_anyOfMatchers(grey_text("FooText"),
+                                     grey_text("Simple Alert"),
+                                     grey_buttonTitle("BarTitle"))
+    EarlGrey().selectElementWithMatcher(matcher).performAction(grey_tap())
+    EarlGrey().selectElementWithMatcher(grey_text("Flee"))
+        .assertWithMatcher(grey_sufficientlyVisible())
+        .performAction(grey_tap())
   }
 
   func openTestView(name:NSString) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -127,6 +127,8 @@ to `Send` and is contained in a UI element that is an instance of the `SendMessa
     performAction:grey_tap()];
 ```
 
+Note: For compatibility with Swift, we use `grey_allOfMatchers()` and `grey_anyOfMatchers()` instead of `grey_allOf()` and `grey_anyOf()` respectively.
+
 #### Custom Matchers
 
 To create custom matchers, use the block-based [GREYElementMatcherBlock](../EarlGrey/Matcher/GREYElementMatcherBlock.h)

--- a/docs/downloads/EarlGrey.swift
+++ b/docs/downloads/EarlGrey.swift
@@ -14,7 +14,15 @@
 // limitations under the License.
 //
 
-public func EarlGrey() -> EarlGreyImpl {
+func grey_allOfMatchers(args: AnyObject...) -> GREYMatcher! {
+  return GREYAllOf.init(matchers: args)
+}
+
+func grey_anyOfMatchers(args: AnyObject...) -> GREYMatcher! {
+  return GREYAnyOf.init(matchers: args)
+}
+
+public func EarlGrey() -> EarlGreyImpl! {
   return EarlGreyImpl.invokedFromFile(#file, lineNumber: #line)
 }
 

--- a/docs/install-and-run.md
+++ b/docs/install-and-run.md
@@ -277,3 +277,4 @@ functions that implement C preprocessor macros that aren't available in Swift.
    EarlGrey().selectElementWithMatcher(grey_accessibilityID("ClickMe"))
        .assertWithMatcher(grey_sufficientlyVisible())
    ```
+3. For compatibility with Swift, we use `grey_allOfMatchers()` and `grey_anyOfMatchers()` instead of `grey_allOf()` and `grey_anyOf()` respectively.


### PR DESCRIPTION
Required for: https://github.com/google/EarlGrey/issues/13