### PR TITLE
Cleaning up error messages and removing unused states from the state.

### DIFF
--- a/EarlGrey/Additions/CALayer+GREYAdditions.m
+++ b/EarlGrey/Additions/CALayer+GREYAdditions.m
@@ -186,28 +186,28 @@ static void const *const kPausedAnimationKeys = &kPausedAnimationKeys;
 }
 
 - (void)greyswizzled_setNeedsDisplayInRect:(CGRect)invalidRect {
-  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, self);
+  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, self);
   // Next runloop drain will perform the draw pass.
   dispatch_async(dispatch_get_main_queue(), ^{
-    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID);
+    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID);
   });
   INVOKE_ORIGINAL_IMP1(void, @selector(greyswizzled_setNeedsDisplayInRect:), invalidRect);
 }
 
 - (void)greyswizzled_setNeedsDisplay {
-  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, self);
+  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, self);
   // Next runloop drain will perform the draw pass.
   dispatch_async(dispatch_get_main_queue(), ^{
-    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID);
+    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID);
   });
   INVOKE_ORIGINAL_IMP(void, @selector(greyswizzled_setNeedsDisplay));
 }
 
 - (void)greyswizzled_setNeedsLayout {
-  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, self);
+  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, self);
   // Next runloop drain will perform the layout pass.
   dispatch_async(dispatch_get_main_queue(), ^ {
-    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID);
+    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID);
   });
   INVOKE_ORIGINAL_IMP(void, @selector(greyswizzled_setNeedsLayout));
 }

--- a/EarlGrey/Additions/UIView+GREYAdditions.m
+++ b/EarlGrey/Additions/UIView+GREYAdditions.m
@@ -313,37 +313,37 @@ static void const *const kOriginalAlphaKey = &kOriginalAlphaKey;
 }
 
 - (void)greyswizzled_setNeedsDisplayInRect:(CGRect)rect {
-  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, self);
+  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, self);
   // Next runloop drain will perform the draw pass.
   dispatch_async(dispatch_get_main_queue(), ^ {
-    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID);
+    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID);
   });
   INVOKE_ORIGINAL_IMP1(void, @selector(greyswizzled_setNeedsDisplayInRect:), rect);
 }
 
 - (void)greyswizzled_setNeedsDisplay {
-  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, self);
+  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, self);
   // Next runloop drain will perform the draw pass.
   dispatch_async(dispatch_get_main_queue(), ^ {
-    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID);
+    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID);
   });
   INVOKE_ORIGINAL_IMP(void, @selector(greyswizzled_setNeedsDisplay));
 }
 
 - (void)greyswizzled_setNeedsLayout {
-  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, self);
+  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, self);
   // Next runloop drain will perform the draw pass.
   dispatch_async(dispatch_get_main_queue(), ^ {
-    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID);
+    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID);
   });
   INVOKE_ORIGINAL_IMP(void, @selector(greyswizzled_setNeedsLayout));
 }
 
 - (void)greyswizzled_setNeedsUpdateConstraints {
-  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, self);
+  NSString *elementID = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, self);
   // Next runloop drain will perform the draw pass.
   dispatch_async(dispatch_get_main_queue(), ^ {
-    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID);
+    UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID);
   });
   INVOKE_ORIGINAL_IMP(void, @selector(greyswizzled_setNeedsUpdateConstraints));
 }

--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.h
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.h
@@ -91,8 +91,16 @@ UIKIT_EXTERN NSString *const kGREYXCTestCaseNotificationKey;
 /**
  *  Interrupts the current test case execution immediately, tears down the test and marks it as
  *  failed.
+ *
+ *  @param line        Line number at which the failure occured.
+ *  @param file        Name of the file in which the failure occured.
+ *  @param reason      Short reason for the failure.
+ *  @param description Full description of the failure.
  */
-- (void)grey_interruptExecution;
+- (void)grey_markAsFailedAtLine:(NSUInteger)line
+                         inFile:(NSString *)file
+                         reason:(NSString *)reason
+              detailDescription:(NSString *)description;
 
 /**
  *  @return A unique test outputs directory for the current test. All test related outputs should be

--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.m
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.m
@@ -165,7 +165,17 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
   return localizedTestOutputsDir;
 }
 
-- (void)grey_interruptExecution {
+- (void)grey_markAsFailedAtLine:(NSUInteger)line
+                         inFile:(NSString *)file
+                         reason:(NSString *)reason
+              detailDescription:(NSString *)description {
+  NSString *fullException =
+      [NSString stringWithFormat:@"%@%@\n%@", reason, [NSThread callStackSymbols], description];
+  gCurrentExecutingTestCase.continueAfterFailure = NO;
+  [gCurrentExecutingTestCase recordFailureWithDescription:fullException
+                                                   inFile:file
+                                                   atLine:line
+                                                 expected:NO];
   [[GREYFrameworkException exceptionWithName:kInternalTestInterruptException
                                       reason:@"Immediately halt execution of testcase"] raise];
 }
@@ -226,7 +236,7 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
     } @catch(NSException *exception) {
       [self grey_setStatus:kGREYXCTestCaseStatusFailed];
       if (![exception.name isEqualToString:kInternalTestInterruptException]) {
-        [exception raise];
+        @throw;
       }
     } @finally {
       switch ([self grey_status]) {

--- a/EarlGrey/Core/GREYKeyboard.m
+++ b/EarlGrey/Core/GREYKeyboard.m
@@ -230,11 +230,12 @@ static NSString *const kReturnKeyIdentifier = @"\n";
                                                                          error:errorOrNil];
       }
     }
-    // A period key for an email UITextField beyond iOS9 types the email domain by default. This
-    // behavior is added to prevent this.
+    // A period key for an email UITextField on iOS9 and above types the email domain (.com, .org)
+    // by default. That is not the desired behavior so check below disables it.
     BOOL keyboardTypeWasChangedFromEmailType = NO;
     if (iOS9_OR_ABOVE() &&
         [characterAsString isEqualToString:@"."] &&
+        [firstResponder respondsToSelector:@selector(keyboardType)] &&
         [firstResponder keyboardType] == UIKeyboardTypeEmailAddress) {
       [firstResponder setKeyboardType:UIKeyboardTypeDefault];
       keyboardTypeWasChangedFromEmailType = YES;
@@ -342,8 +343,8 @@ static NSString *const kReturnKeyIdentifier = @"\n";
   [NSError grey_logOrSetOutReferenceIfNonNil:errorOrNil
                                   withDomain:kGREYInteractionErrorDomain
                                         code:kGREYInteractionActionFailedErrorCode
-                        andDescriptionFormat:@"GREYKeyboard: No known SHIFT key was found in the"
-                                             @" hierarchy."];
+                        andDescriptionFormat:@"GREYKeyboard: No known SHIFT key was found in the "
+                                             @"hierarchy."];
   return NO;
 }
 

--- a/EarlGrey/Synchronization/GREYAppStateTracker.h
+++ b/EarlGrey/Synchronization/GREYAppStateTracker.h
@@ -32,15 +32,15 @@ typedef NS_OPTIONS(NSUInteger, GREYAppState){
    */
   kGREYIdle = 0,
   /**
-   *  View is pending drawing cycle.
+   *  View is pending draw or layout pass.
    */
-  kGREYPendingDrawCycle = (1UL << 0),
+  kGREYPendingDrawLayoutPass = (1UL << 0),
   /**
-   *  Waiting for views to appear.
+   *  Waiting for viewDidAppear: method invocation.
    */
   kGREYPendingViewsToAppear = (1UL << 1),
   /**
-   *  Waiting for views to disappear.
+   *  Waiting for viewDidDisappear: method invocation.
    */
   kGREYPendingViewsToDisappear = (1UL << 2),
   /**
@@ -48,50 +48,38 @@ typedef NS_OPTIONS(NSUInteger, GREYAppState){
    */
   kGREYPendingKeyboardTransition = (1UL << 3),
   /**
-   *  Pending CA animation.
+   *  Waiting for CA animation to complete.
    */
   kGREYPendingCAAnimation = (1UL << 4),
   /**
-   *  Waiting for actionsheet's window to be removed.
+   *  Waiting for a UIAnimation to be marked as stopped.
    */
-  kGREYPendingActionSheetToDisappear = (1UL << 5),
-  /**
-   *  Pending UIView animation
-   */
-  kGREYPendingUIViewAnimation = (1UL << 6),
-  /**
-   *  Pending UIViewController to move to parent.
-   */
-  kGREYPendingMoveToParent = (1UL << 7),
+  kGREYPendingUIAnimation = (1UL << 5),
   /**
    *  Pending root view controller to be set.
    */
-  kGREYPendingRootViewControllerToAppear = (1UL << 8),
+  kGREYPendingRootViewControllerToAppear = (1UL << 6),
   /**
    *  Pending a UIWebView async load request
    */
-  kGREYPendingUIWebViewAsyncRequest = (1UL << 9),
+  kGREYPendingUIWebViewAsyncRequest = (1UL << 7),
   /**
    *  Pending a network request completion.
    */
-  kGREYPendingNetworkRequest = (1UL << 10),
+  kGREYPendingNetworkRequest = (1UL << 8),
   /**
    *  Pending gesture recognition.
    */
-  kGREYPendingGestureRecognition = (1UL << 11),
+  kGREYPendingGestureRecognition = (1UL << 9),
   /**
    *  Waiting for UIScrollView to finish scrolling.
    */
-  kGREYPendingUIScrollViewScrolling = (1UL << 12),
+  kGREYPendingUIScrollViewScrolling = (1UL << 10),
   /**
    *  [UIApplication beginIgnoringInteractionEvents] was called and all interaction events are
    *  being ignored.
    */
-  kGREYIgnoringSystemWideUserInteraction = (1UL << 13),
-  /**
-   *  Waiting for a UIAnimation to be marked as stopped.
-   */
-  kGREYPendingUIAnimation = (1UL << 14),
+  kGREYIgnoringSystemWideUserInteraction = (1UL << 11),
 };
 
 /**

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ configured, take a look at the EarlGrey API and start writing your own tests.
 
 If you need help, several resources are available. First check the [FAQ](https://github.com/google/EarlGrey/tree/master/docs/faq.md).
 If you have more questions after reading the FAQ, see [Known Issues](https://github.com/google/EarlGrey/tree/master/docs/known-issues.md).
-If you still have questions, you can bring them to our attention by asking them on
+You can bring more specific issues to our attention by asking them on
 [stackoverflow.com](http://stackoverflow.com/) using the [#earlgrey tag](http://stackoverflow.com/questions/tagged/earlgrey).
-You can also start new discussions with us on our [Google group](https://groups.google.com/forum/#!forum/earlgrey-discuss).
+You can also start new discussions with us on our [Google group](https://groups.google.com/forum/#!forum/earlgrey-discuss)
+or request to join our [slack channel](https://googleoss.slack.com/messages/earlgrey).
 
   * [FAQ](https://github.com/google/EarlGrey/tree/master/docs/faq.md)
   * [Known Issues](https://github.com/google/EarlGrey/tree/master/docs/known-issues.md)
   * [Stack Overflow](http://stackoverflow.com/questions/tagged/earlgrey)
+  * [Slack](https://googleoss.slack.com/messages/earlgrey)
   * [Google Group](https://groups.google.com/forum/#!forum/earlgrey-discuss)
 
 ## Analytics

--- a/Tests/FunctionalTests/Sources/FTRBaseIntegrationTest.m
+++ b/Tests/FunctionalTests/Sources/FTRBaseIntegrationTest.m
@@ -50,6 +50,7 @@
   }
   [navController popToRootViewControllerAnimated:YES];
 
+  [[GREYConfiguration sharedInstance] reset];
   [EarlGrey setFailureHandler:_currentFailureHandler];
 
   [super tearDown];

--- a/Tests/FunctionalTests/TestRig/Sources/FTRTableViewController.h
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRTableViewController.h
@@ -20,9 +20,4 @@
 @property(retain, nonatomic) IBOutlet UITableView *mainTableView;
 @property(weak, nonatomic) IBOutlet UITextField *insetsValue;
 
-// Throws an error if tableview's delegate is asked to deque cell at specified |index|. It is
-// useful for cases where we want to make sure EarlGrey data providers are not unnecessarily
-// traversing cells that they don't need to.
-+ (void)throwErrorIfElementProviderDequeuesCellAtIndex:(NSInteger)index;
-
 @end

--- a/Tests/FunctionalTests/TestRig/Sources/FTRTableViewController.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRTableViewController.m
@@ -17,19 +17,9 @@
 #import "FTRTableViewController.h"
 
 static NSString *gTableViewIdentifier = @"TableViewCellReuseIdentifier";
-static NSInteger gThrowErrorWhenCellDequedAtIndex = -1;
 
 @implementation FTRTableViewController {
   NSMutableArray *_rowIndicesRemoved;
-}
-
-+ (void)throwErrorIfElementProviderDequeuesCellAtIndex:(NSInteger)index {
-  gThrowErrorWhenCellDequedAtIndex = index;
-}
-
-- (instancetype)init {
-  NSAssert(NO, @"Invalid Initializer");
-  return nil;
 }
 
 - (void)viewDidLoad {
@@ -71,12 +61,7 @@ static NSInteger gThrowErrorWhenCellDequedAtIndex = -1;
 
 - (UITableViewCell *)tableView:(UITableView *)tableView
        cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-  if (indexPath.row == gThrowErrorWhenCellDequedAtIndex) {
-    [NSException raise:@"CellDequedAtForbiddenIndex"
-                format:@"Cell was dequed at index %zd", gThrowErrorWhenCellDequedAtIndex];
-  }
   UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:gTableViewIdentifier];
-
   if (cell == nil) {
     cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault
                                   reuseIdentifier:gTableViewIdentifier];

--- a/Tests/UnitTests/Sources/CALayer+GREYAdditionsTest.m
+++ b/Tests/UnitTests/Sources/CALayer+GREYAdditionsTest.m
@@ -57,7 +57,7 @@ static const CFTimeInterval kMaxAnimationInterval = 5.0;
   // objc_precise_lifetime required so layer is valid until end of the current scope.
   __attribute__((objc_precise_lifetime)) CALayer *layer = [[CALayer alloc] init];
   [layer setNeedsLayout];
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"Should change state.");
 
@@ -65,14 +65,14 @@ static const CFTimeInterval kMaxAnimationInterval = 5.0;
 
   layer = [[CALayer alloc] init];
   [layer setNeedsDisplay];
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"Should change state.");
 
   [[GREYAppStateTracker sharedInstance] grey_clearState];
   layer = [[CALayer alloc] init];
   [layer setNeedsDisplayInRect:CGRectMake(0, 0, 0, 0)];
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"Should change state.");
 }

--- a/Tests/UnitTests/Sources/GREYAppStateTrackerTest.m
+++ b/Tests/UnitTests/Sources/GREYAppStateTrackerTest.m
@@ -42,12 +42,12 @@
                  [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:obj2],
                  @"Default state should be kGREYIdle");
 
-  NSString *elementID2 = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, obj2);
+  NSString *elementID2 = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, obj2);
 
   XCTAssertEqual(kGREYPendingCAAnimation,
                  [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:obj1],
                  @"State should be kGREYPendingCAAnimation");
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:obj2],
                  @"State should be kGREYPendingDrawCycle");
 
@@ -56,11 +56,11 @@
   XCTAssertEqual(kGREYIdle,
                  [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:obj1],
                  @"State should be kGREYIdle");
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:obj2],
                  @"State should be kGREYPendingDrawCycle");
 
-  UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID2);
+  UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID2);
 
   XCTAssertEqual(kGREYIdle,
                  [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:obj1],
@@ -85,19 +85,19 @@
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"State should be kGREYPendingCAAnimation");
 
-  NSString *elementID2 = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawCycle, obj2);
+  NSString *elementID2 = TRACK_STATE_FOR_ELEMENT(kGREYPendingDrawLayoutPass, obj2);
 
-  XCTAssertEqual(kGREYPendingCAAnimation | kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingCAAnimation | kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"State should be kGREYPendingCAAnimation and kGREYPendingDrawCycle");
 
   UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingCAAnimation, elementID1);
 
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"State should be kGREYPendingDrawCycle");
 
-  UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawCycle, elementID2);
+  UNTRACK_STATE_FOR_ELEMENT_WITH_ID(kGREYPendingDrawLayoutPass, elementID2);
 
   XCTAssertEqual(kGREYIdle,
                  [[GREYAppStateTracker sharedInstance] currentState],

--- a/Tests/UnitTests/Sources/UIView+GREYAdditionsTest.m
+++ b/Tests/UnitTests/Sources/UIView+GREYAdditionsTest.m
@@ -184,25 +184,25 @@
   // objc_precise_lifetime required so view is valid until end of the current scope.
   __attribute__((objc_precise_lifetime)) UIView *view = [[UIView alloc] init];
   [view setNeedsDisplay];
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"Should change state.");
 
   [[GREYAppStateTracker sharedInstance] grey_clearState];
   [view setNeedsDisplayInRect:CGRectMake(0, 0, 0, 0)];
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"Should change state.");
 
   [[GREYAppStateTracker sharedInstance] grey_clearState];
   [view setNeedsLayout];
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"Should change state.");
 
   [[GREYAppStateTracker sharedInstance] grey_clearState];
   [view setNeedsUpdateConstraints];
-  XCTAssertEqual(kGREYPendingDrawCycle,
+  XCTAssertEqual(kGREYPendingDrawLayoutPass,
                  [[GREYAppStateTracker sharedInstance] currentState],
                  @"Should change state.");
 }


### PR DESCRIPTION
- Clean up error messages
- Remove unused statetracker states
- fix for a bug that applied search action one last time just before a timeout without checking the hierarchy again. As a result, the screenshot was different from when the actual failure was expected to occur.