### PR TITLE
Fix Ruby build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@
 language: objective-c
 osx_image: xcode7.3
 sudo: false
+rvm:
+  - 2.2.2
 env:
   matrix:
     - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -22,6 +22,7 @@ xcodebuild -showsdks
 if [ "${TYPE}" == "UNIT" ]; then
   env NSUnbufferedIO=YES xcodebuild -project Tests/UnitTests/UnitTests.xcodeproj -scheme EarlGreyUnitTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
 elif [ "${TYPE}" == "RUBY" ]; then
+  rvm use 2.2.2;
   cd gem;
   bundle install --retry=3;
   rake;


### PR DESCRIPTION
Cocoapods xcodeproj depends on Rails activesupport which
requires Ruby 2.2.2 as of the 5.0 release.

> Ruby 2.2.2+ is now also the only supported version of Rails 5.0+.
>
> http://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/#yay
> https://rubygems.org/gems/activesupport