### PR TITLE
New GREYAsserts, UIApplicationDelegate fix, style fixes, remove dead code

### DIFF
--- a/EarlGrey/Assertion/GREYAssertionDefines.h
+++ b/EarlGrey/Assertion/GREYAssertionDefines.h
@@ -96,7 +96,8 @@ GREY_EXTERN id<GREYFailureHandler> greyFailureHandler;
   I_GREYAssertNil(__a1, __description, ##__VA_ARGS__)
 
 /**
- *  Generates a failure with the provided @c __description if @c __a1 and @c __a2 are not equal.
+ *  Generates a failure with the provided @c __description if the expression @c __a1 and
+ *  the expression @c __a2 are not equal.
  *  @c __a1 and @c __a2 must be scalar types.
  *
  *  @param __a1          The left hand scalar value on the equality operation.
@@ -108,6 +109,51 @@ GREY_EXTERN id<GREYFailureHandler> greyFailureHandler;
 #define GREYAssertEqual(__a1, __a2, __description, ...) \
   I_GREYSetCurrentAsFailable(); \
   I_GREYAssertEqual(__a1, __a2, __description, ##__VA_ARGS__)
+
+/**
+ *  Generates a failure with the provided @c __description if the expression @c __a1 and
+ *  the expression @c __a2 are equal.
+ *  @c __a1 and @c __a2 must be scalar types.
+ *
+ *  @param __a1          The left hand scalar value on the equality operation.
+ *  @param __a2          The right hand scalar value on the equality operation.
+ *  @param __description Description to print if @c __a1 and @c __a2 are equal. May be a format
+ *                       string, in which case the variable args will be required.
+ *  @param ...           Variable args for @c __description if it is a format string.
+ */
+#define GREYAssertNotEqual(__a1, __a2, __description, ...) \
+  I_GREYSetCurrentAsFailable(); \
+  I_GREYAssertNotEqual(__a1, __a2, __description, ##__VA_ARGS__)
+
+/**
+ *  Generates a failure with the provided @c __description if the expression @c __a1 and
+ *  the expression @c __a2 are not equal.
+ *  @c __a1 and @c __a2 must be descendants of NSObject and will be compared with method isEqual.
+ *
+ *  @param __a1          The left hand object on the equality operation.
+ *  @param __a2          The right hand object on the equality operation.
+ *  @param __description Description to print if @c __a1 and @c __a2 are not equal. May be a format
+ *                       string, in which case the variable args will be required.
+ *  @param ...           Variable args for @c __description if it is a format string.
+ */
+#define GREYAssertEqualObjects(__a1, __a2, __description, ...) \
+  I_GREYSetCurrentAsFailable(); \
+  I_GREYAssertEqualObjects(__a1, __a2, __description, ##__VA_ARGS__)
+
+/**
+ *  Generates a failure with the provided @c __description if the expression @c __a1 and
+ *  the expression @c __a2 are equal.
+ *  @c __a1 and @c __a2 must be descendants of NSObject and will be compared with method isEqual.
+ *
+ *  @param __a1          The left hand object on the equality operation.
+ *  @param __a2          The right hand object on the equality operation.
+ *  @param __description Description to print if @c __a1 and @c __a2 are equal. May be a format
+ *                       string, in which case the variable args will be required.
+ *  @param ...           Variable args for @c __description if it is a format string.
+ */
+#define GREYAssertNotEqualObjects(__a1, __a2, __description, ...) \
+  I_GREYSetCurrentAsFailable(); \
+  I_GREYAssertNotEqualObjects(__a1, __a2, __description, ##__VA_ARGS__)
 
 /**
  *  Generates a failure unconditionally, with the provided @c __description.
@@ -218,6 +264,39 @@ GREY_EXTERN id<GREYFailureHandler> greyFailureHandler;
       I_GREYFormattedString(formattedDescription__, __description, ##__VA_ARGS__); \
       I_GREYRegisterFailure(kGREYAssertionFailedException, \
                             @"((" #__a1 ") == (" #__a2 ")) failed", \
+                            formattedDescription__); \
+    } \
+  } while(NO)
+
+#define I_GREYAssertNotEqual(__a1, __a2, __description, ...) \
+  do { \
+    if ((__a1) == (__a2)) { \
+      NSString *formattedDescription__; \
+      I_GREYFormattedString(formattedDescription__, __description, ##__VA_ARGS__); \
+      I_GREYRegisterFailure(kGREYAssertionFailedException, \
+                            @"((" #__a1 ") != (" #__a2 ")) failed", \
+                            formattedDescription__); \
+    } \
+  } while(NO)
+
+#define I_GREYAssertEqualObjects(__a1, __a2, __description, ...) \
+  do { \
+    if (![(__a1) isEqual:(__a2)]) { \
+      NSString *formattedDescription__; \
+      I_GREYFormattedString(formattedDescription__, __description, ##__VA_ARGS__); \
+      I_GREYRegisterFailure(kGREYAssertionFailedException, \
+                            @"[(" #__a1 ") isEqual:(" #__a2 ")] failed", \
+                            formattedDescription__); \
+    } \
+  } while(NO)
+
+#define I_GREYAssertNotEqualObjects(__a1, __a2, __description, ...) \
+  do { \
+    if ([(__a1) isEqual:(__a2)]) { \
+      NSString *formattedDescription__; \
+      I_GREYFormattedString(formattedDescription__, __description, ##__VA_ARGS__); \
+      I_GREYRegisterFailure(kGREYAssertionFailedException, \
+                            @"![(" #__a1 ") isEqual:(" #__a2 ")] failed", \
                             formattedDescription__); \
     } \
   } while(NO)

--- a/EarlGrey/Core/GREYElementInteraction.m
+++ b/EarlGrey/Core/GREYElementInteraction.m
@@ -113,7 +113,7 @@ NSString *const kGREYAssertionErrorUserInfoKey = @"kGREYAssertionErrorUserInfoKe
   NSError *searchActionError = nil;
   CFTimeInterval timeoutTime = CACurrentMediaTime() + timeout;
   BOOL timedOut = NO;
-  while(true) {
+  while (YES) {
     @autoreleasepool {
       // Find the element in the current UI hierarchy.
       NSArray *elements = [elementFinder elementsMatchedInProvider:entireRootHierarchyProvider];
@@ -149,7 +149,7 @@ NSString *const kGREYAssertionErrorUserInfoKey = @"kGREYAssertionErrorUserInfoKe
   NSDictionary *userInfo = nil;
   if (searchActionError) {
     userInfo = @{ NSUnderlyingErrorKey : searchActionError };
-  } else if (CACurrentMediaTime() >= timeoutTime) {
+  } else if (timedOut) {
     CFTimeInterval interactionTimeout =
         GREY_CONFIG_DOUBLE(kGREYConfigKeyInteractionTimeoutDuration);
     NSString *desc = [NSString stringWithFormat:@"Timeout (currently set to %g) occurred when "
@@ -377,6 +377,7 @@ NSString *const kGREYAssertionErrorUserInfoKey = @"kGREYAssertionErrorUserInfoKe
              onElementWithMatcher:(id<GREYMatcher>)matcher {
   NSParameterAssert(action);
   NSParameterAssert(matcher);
+  
   _searchActionElementMatcher = matcher;
   _searchAction = action;
   return self;

--- a/EarlGrey/Matcher/GREYHCMatcher.h
+++ b/EarlGrey/Matcher/GREYHCMatcher.h
@@ -24,7 +24,7 @@
 @interface GREYHCMatcher : NSObject<GREYMatcher>
 
 /**
- *  This method takes in a matcher object conforming to HCMatcher protocl and returns an object
+ *  This method takes in a matcher object conforming to HCMatcher protocol and returns an object
  *  conforming to the GREYMatcher protocol.
  *
  *  @param HCMatcher The OCHamcrest matcher to be transformed.

--- a/EarlGrey/Provider/GREYUIWindowProvider.m
+++ b/EarlGrey/Provider/GREYUIWindowProvider.m
@@ -56,22 +56,23 @@
 }
 
 + (NSArray *)allWindows {
+  UIApplication *sharedApp = UIApplication.sharedApplication;
   NSMutableOrderedSet *windows = [[NSMutableOrderedSet alloc] init];
-  if (UIApplication.sharedApplication.windows) {
-    [windows addObjectsFromArray:UIApplication.sharedApplication.windows];
+  if (sharedApp.windows) {
+    [windows addObjectsFromArray:sharedApp.windows];
   }
 
-  if (UIApplication.sharedApplication.delegate.window) {
-    [windows addObject:UIApplication.sharedApplication.delegate.window];
+  if ([sharedApp.delegate respondsToSelector:@selector(window)] && sharedApp.delegate.window) {
+    [windows addObject:sharedApp.delegate.window];
   }
 
-  if (UIApplication.sharedApplication.keyWindow) {
-    [windows addObject:UIApplication.sharedApplication.keyWindow];
+  if (sharedApp.keyWindow) {
+    [windows addObject:sharedApp.keyWindow];
   }
 
   BOOL includeStatusBarWindow = GREY_CONFIG_BOOL(kGREYConfigKeyIncludeStatusBarWindow);
-  if (includeStatusBarWindow && UIApplication.sharedApplication.statusBarWindow) {
-    [windows addObject:UIApplication.sharedApplication.statusBarWindow];
+  if (includeStatusBarWindow && sharedApp.statusBarWindow) {
+    [windows addObject:sharedApp.statusBarWindow];
   }
 
   // After sorting, reverse the windows because they need to appear from top-most to bottom-most.

--- a/EarlGrey/Synchronization/GREYRunLoopSpinner.m
+++ b/EarlGrey/Synchronization/GREYRunLoopSpinner.m
@@ -46,6 +46,7 @@ static void (^noopTimerHandler)(CFRunLoopTimerRef timer) = ^(CFRunLoopTimerRef t
 - (BOOL)spinWithStopConditionBlock:(BOOL (^)(void))stopConditionBlock {
   I_CHECK_MAIN_THREAD();
   NSAssert(!_spinning, @"Should not spin the same run loop spinner instance concurrently.");
+  
   _spinning = YES;
   CFTimeInterval timeoutTime = CACurrentMediaTime() + self.timeout;
 

--- a/Tests/FunctionalTests/Sources/EarlGrey.swift
+++ b/Tests/FunctionalTests/Sources/EarlGrey.swift
@@ -39,7 +39,7 @@ public func GREYAssertTrue(@autoclosure expression: () -> BooleanType, reason: S
 public func GREYAssertFalse(@autoclosure expression: () -> BooleanType, reason: String) {
   GREYAssert(!expression().boolValue,
     reason,
-    details: "Expected the boolean expression to be true")
+    details: "Expected the boolean expression to be false")
 }
 
 public func GREYAssertNotNil(@autoclosure expression: () -> Any?, reason: String) {
@@ -52,7 +52,12 @@ public func GREYAssertNil(@autoclosure expression: () -> Any?, reason: String) {
 
 public func GREYAssertEqual<T : Equatable>(@autoclosure left: () -> T?,
     @autoclosure _ right: () -> T?, reason: String) {
-  GREYAssert(left() == right(), reason, details: "Expeted left term to be equal to right term")
+  GREYAssert(left() == right(), reason, details: "Expected left term to be equal to right term")
+}
+
+public func GREYAssertNotEqual<T : Equatable>(@autoclosure left: () -> T?,
+    @autoclosure _ right: () -> T?, reason: String) {
+  GREYAssert(left() != right(), reason, details: "Expected left term to not be equal to right term")
 }
 
 public func GREYFail(reason: String) {

--- a/Tests/FunctionalTests/Sources/FTRAccessibilityTest.m
+++ b/Tests/FunctionalTests/Sources/FTRAccessibilityTest.m
@@ -119,7 +119,7 @@
     XCTFail(@"Should throw an exception");
   } @catch (NSException *exception) {
     NSRange exceptionRange = [[exception reason] rangeOfString:@"Action 'Tap' failed."];
-    XCTAssertNotEqual(exceptionRange.location, (NSUInteger)NSNotFound);
+    GREYAssertNotEqual(exceptionRange.location, NSNotFound, @"should not be equal");
   }
 }
 

--- a/Tests/FunctionalTests/Sources/FTRActionSheetTest.m
+++ b/Tests/FunctionalTests/Sources/FTRActionSheetTest.m
@@ -1,3 +1,19 @@
+//
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 #import "FTRBaseIntegrationTest.h"
 
 @interface FTRActionSheetTest : FTRBaseIntegrationTest

--- a/Tests/FunctionalTests/Sources/FTRAnalyticsTest.m
+++ b/Tests/FunctionalTests/Sources/FTRAnalyticsTest.m
@@ -30,7 +30,7 @@ static BOOL gAnalyticsShouldBeSent = NO;
   XCTAssertTrue(GREY_CONFIG_BOOL(kGREYConfigKeyAnalyticsEnabled));
 }
 
-- (void)testAnalyticsNotSent {
+- (void)testAnalyticsSent {
   gAnalyticsShouldBeSent = YES;
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationPortrait errorOrNil:nil];
   // Verify that analytics is enabled by default.

--- a/Tests/FunctionalTests/Sources/FTRAnalyticsTest.m
+++ b/Tests/FunctionalTests/Sources/FTRAnalyticsTest.m
@@ -27,14 +27,14 @@ static BOOL gAnalyticsShouldBeSent = NO;
 - (void)testAnalyticsIsEnabled {
   gAnalyticsShouldBeSent = NO;
   // Verify that analytics is enabled by default.
-  XCTAssertTrue(GREY_CONFIG_BOOL(kGREYConfigKeyAnalyticsEnabled));
+  GREYAssertTrue(GREY_CONFIG_BOOL(kGREYConfigKeyAnalyticsEnabled), @"should be true");
 }
 
 - (void)testAnalyticsSent {
   gAnalyticsShouldBeSent = YES;
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationPortrait errorOrNil:nil];
   // Verify that analytics is enabled by default.
-  XCTAssertTrue(GREY_CONFIG_BOOL(kGREYConfigKeyAnalyticsEnabled));
+  GREYAssertTrue(GREY_CONFIG_BOOL(kGREYConfigKeyAnalyticsEnabled), @"should be true");
 }
 
 + (void)tearDown {

--- a/Tests/FunctionalTests/Sources/FTRErrorAPITest.m
+++ b/Tests/FunctionalTests/Sources/FTRErrorAPITest.m
@@ -37,6 +37,10 @@
   GREYAssertTrue(1 == 1, @"1 should be equal to 1");
   GREYAssertFalse(0 == 1, @"0 shouldn't be equal to 1");
   GREYAssertEqual(1, 1, @"1 should be equal to 1");
+  GREYAssertNotEqual(1, 2, @"1 should not be equal to 2");
+  GREYAssertEqualObjects(@"foo", [[NSString alloc] initWithFormat:@"foo"],
+                         @"strings foo must be equal");
+  GREYAssertNotEqualObjects(@"foo", @"bar", @"string foo and bar must not be equal");
   GREYAssertNil(nil, @"nil should be nil");
   GREYAssertNotNil([[NSObject alloc] init], @"a valid object should not be nil");
 }

--- a/Tests/FunctionalTests/Sources/FTRGeometryTest.m
+++ b/Tests/FunctionalTests/Sources/FTRGeometryTest.m
@@ -27,7 +27,7 @@
 
 - (void)testCGRectFixedToVariableScreenCoordinates_portrait {
   CGRect actualRect = CGRectFixedToVariableScreenCoordinates(CGRectMake(40, 50, 100, 120));
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(40, 50, 100, 120), actualRect));
+  GREYAssertTrue(CGRectEqualToRect(CGRectMake(40, 50, 100, 120), actualRect), @"should be true");
 }
 
 - (void)testCGRectFixedToVariableScreenCoordinates_portraitUpsideDown {
@@ -43,7 +43,7 @@
                                    100, 120);
   CGRect actualRect = CGRectFixedToVariableScreenCoordinates(CGRectMake(40, 50, 100, 120));
 
-  XCTAssertTrue(CGRectEqualToRect(expectedRect, actualRect));
+  GREYAssertTrue(CGRectEqualToRect(expectedRect, actualRect), @"should be true");
 }
 
 - (void)testCGRectFixedToVariableScreenCoordinates_landscapeRight {
@@ -59,7 +59,7 @@
                                   10, 20);
   CGRect actualRect = CGRectFixedToVariableScreenCoordinates(rectInFixed);
   CGRect expectedRect = CGRectMake(0, 0, 20, 10);
-  XCTAssertTrue(CGRectEqualToRect(expectedRect, actualRect));
+  GREYAssertTrue(CGRectEqualToRect(expectedRect, actualRect), @"should be true");
 
   // Bottom right => Bottom left
   rectInFixed = CGRectMake((iOS8_0_OR_ABOVE() ? height : width) - 10,
@@ -67,14 +67,14 @@
                            10, 20);
   actualRect = CGRectFixedToVariableScreenCoordinates(rectInFixed);
   expectedRect = CGRectMake(0, (iOS8_0_OR_ABOVE() ? height : width) - 10, 20, 10);
-  XCTAssertTrue(CGRectEqualToRect(expectedRect, actualRect));
+  GREYAssertTrue(CGRectEqualToRect(expectedRect, actualRect), @"should be true");
 
   // Too left => Top right
   rectInFixed = CGRectMake(0, 0, 10, 20);
   actualRect = CGRectFixedToVariableScreenCoordinates(rectInFixed);
   expectedRect = CGRectMake((iOS8_0_OR_ABOVE() ? width : height) - 20, 0,
                             20, 10);
-  XCTAssertTrue(CGRectEqualToRect(expectedRect, actualRect));
+  GREYAssertTrue(CGRectEqualToRect(expectedRect, actualRect), @"should be true");
 
   // Too right => bottom right
   rectInFixed = CGRectMake((iOS8_0_OR_ABOVE() ? height : width) - 10, 0,
@@ -83,7 +83,7 @@
   expectedRect = CGRectMake((iOS8_0_OR_ABOVE() ? width : height) - 20,
                             (iOS8_0_OR_ABOVE() ? height : width) - 10,
                             20, 10);
-  XCTAssertTrue(CGRectEqualToRect(expectedRect, actualRect));
+  GREYAssertTrue(CGRectEqualToRect(expectedRect, actualRect), @"should be true");
 }
 
 - (void)testCGRectFixedToVariableScreenCoordinates_landscapeLeft {
@@ -96,20 +96,22 @@
 
   CGRect rectInFixed = CGRectMake((iOS8_0_OR_ABOVE() ? height : width) - 120, 50, 120, 100);
   CGRect actualRect = CGRectFixedToVariableScreenCoordinates(rectInFixed);
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(50, 0, 100, 120), actualRect));
+  GREYAssertTrue(CGRectEqualToRect(CGRectMake(50, 0, 100, 120), actualRect),
+                 @"should be true");
 
   rectInFixed = CGRectMake(0, (iOS8_0_OR_ABOVE() ? width : height), 0, 0);
   actualRect = CGRectFixedToVariableScreenCoordinates(rectInFixed);
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake((iOS8_0_OR_ABOVE() ? width : height),
-                                             (iOS8_0_OR_ABOVE() ? height : width), 0, 0),
-                                  actualRect));
+  GREYAssertTrue(CGRectEqualToRect(CGRectMake((iOS8_0_OR_ABOVE() ? width : height),
+                                              (iOS8_0_OR_ABOVE() ? height : width), 0, 0),
+                                   actualRect),
+                 @"should be true");
 }
 
 #pragma mark - CGRectVariableToFixedScreenCoordinates
 
 - (void)testCGRectVariableToFixedScreenCoordinates_portrait {
   CGRect actualRect = CGRectVariableToFixedScreenCoordinates(CGRectMake(40, 50, 100, 120));
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(40, 50, 100, 120), actualRect));
+  GREYAssertTrue(CGRectEqualToRect(CGRectMake(40, 50, 100, 120), actualRect), @"should be true");
 }
 
 - (void)testCGRectVariableToFixedScreenCoordinates_portraitUpsideDown {
@@ -125,7 +127,7 @@
                                    100, 120);
   CGRect actualRect = CGRectVariableToFixedScreenCoordinates(CGRectMake(40, 50, 100, 120));
 
-  XCTAssertTrue(CGRectEqualToRect(expectedRect, actualRect));
+  GREYAssertTrue(CGRectEqualToRect(expectedRect, actualRect), @"should be true");
 }
 
 
@@ -139,8 +141,9 @@
 
   CGRect rectInVariable = CGRectMake(0, 0, 0, 0);
   CGRect actualRect = CGRectVariableToFixedScreenCoordinates(rectInVariable);
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, (iOS8_0_OR_ABOVE() ? width : height), 0, 0),
-                                  actualRect));
+  GREYAssertTrue(CGRectEqualToRect(CGRectMake(0, (iOS8_0_OR_ABOVE() ? width : height), 0, 0),
+                                   actualRect),
+                 @"should be true");
 }
 
 - (void)testCGRectVariableToFixedScreenCoordinates_landscapeLeft {
@@ -153,17 +156,19 @@
 
   CGRect rectInVariable = CGRectMake(50, 0, 100, 120);
   CGRect actualRect = CGRectVariableToFixedScreenCoordinates(rectInVariable);
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake((iOS8_0_OR_ABOVE() ? height : width) - 120,
-                                             50,
-                                             120,
-                                             100),
-                                  actualRect));
+  GREYAssertTrue(CGRectEqualToRect(CGRectMake((iOS8_0_OR_ABOVE() ? height : width) - 120,
+                                              50,
+                                              120,
+                                              100),
+                                   actualRect),
+                 @"should be true");
 
   rectInVariable = CGRectMake((iOS8_0_OR_ABOVE() ? width : height),
                               (iOS8_0_OR_ABOVE() ? height : width), 0, 0);
   actualRect = CGRectVariableToFixedScreenCoordinates(rectInVariable);
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, (iOS8_0_OR_ABOVE() ? width : height), 0, 0),
-                                  actualRect));
+  GREYAssertTrue(CGRectEqualToRect(CGRectMake(0, (iOS8_0_OR_ABOVE() ? width : height), 0, 0),
+                                   actualRect),
+                 @"should be true");
 }
 
 @end

--- a/Tests/FunctionalTests/Sources/FTRGestureTest.m
+++ b/Tests/FunctionalTests/Sources/FTRGestureTest.m
@@ -197,16 +197,6 @@
 
 #pragma mark - Private
 
-- (id<GREYAction>)tapWithAmount:(int)amount {
-  if (amount == 1) {
-    return grey_tap();
-  } else if (amount == 2) {
-    return grey_doubleTap();
-  } else {
-    return grey_multipleTapsWithCount((NSUInteger)amount);
-  }
-}
-
 // Asserts that Swipe works in all directions by verifying if the swipe gestures are correctly
 // recognized.
 - (void)assertSwipeWorksInAllDirections {

--- a/Tests/FunctionalTests/Sources/FTRKeyboardKeysTest.m
+++ b/Tests/FunctionalTests/Sources/FTRKeyboardKeysTest.m
@@ -141,7 +141,7 @@
   } @catch (NSException *exception) {
     NSRange exceptionRange =
         [[exception reason] rangeOfString:@"Action 'Type \"Should Fail\"' failed."];
-    XCTAssertTrue(exceptionRange.length > 0, @"Should throw exception indicating action failure.");
+    GREYAssertTrue(exceptionRange.length > 0, @"Should throw exception indicating action failure.");
   }
 }
 

--- a/Tests/FunctionalTests/Sources/FTROrientationChangeTest.m
+++ b/Tests/FunctionalTests/Sources/FTROrientationChangeTest.m
@@ -31,18 +31,18 @@
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationPortrait errorOrNil:nil];
   // Test rotating to landscape.
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationLandscapeLeft errorOrNil:nil];
-  XCTAssertTrue([UIDevice currentDevice].orientation == UIDeviceOrientationLandscapeLeft,
-                @"Device orientation should now be left landscape");
-  XCTAssertTrue([[UIApplication sharedApplication] statusBarOrientation]
-                == UIInterfaceOrientationLandscapeRight,
-                @"Interface orientation should now be right landscape");
+  GREYAssertTrue([UIDevice currentDevice].orientation == UIDeviceOrientationLandscapeLeft,
+                 @"Device orientation should now be left landscape");
+  GREYAssertTrue([[UIApplication sharedApplication] statusBarOrientation]
+                 == UIInterfaceOrientationLandscapeRight,
+                 @"Interface orientation should now be right landscape");
   // Test rotating to portrait.
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationPortrait errorOrNil:nil];
-  XCTAssertTrue([UIDevice currentDevice].orientation == UIDeviceOrientationPortrait,
-                @"Device orientation should now be portrait");
-  XCTAssertTrue([[UIApplication sharedApplication] statusBarOrientation]
-                == UIInterfaceOrientationPortrait,
-                @"Interface orientation should now be portrait");
+  GREYAssertTrue([UIDevice currentDevice].orientation == UIDeviceOrientationPortrait,
+                 @"Device orientation should now be portrait");
+  GREYAssertTrue([[UIApplication sharedApplication] statusBarOrientation]
+                 == UIInterfaceOrientationPortrait,
+                 @"Interface orientation should now be portrait");
 }
 
 - (void)testRotateToCurrentOrientation {
@@ -52,11 +52,11 @@
   // We have to rotate device twice to test behavior of rotating to the same deviceOrientation,
   // because device orientation could be unknown, or face up, or face down at this point.
   [EarlGrey rotateDeviceToOrientation:deviceOrientation errorOrNil:nil];
-  XCTAssertTrue([UIDevice currentDevice].orientation == deviceOrientation,
-                @"Device orientation should match");
+  GREYAssertTrue([UIDevice currentDevice].orientation == deviceOrientation,
+                 @"Device orientation should match");
   [EarlGrey rotateDeviceToOrientation:deviceOrientation errorOrNil:nil];
-  XCTAssertTrue([UIDevice currentDevice].orientation == deviceOrientation,
-                @"Device orientation should match");
+  GREYAssertTrue([UIDevice currentDevice].orientation == deviceOrientation,
+                 @"Device orientation should match");
 }
 
 - (void)testInteractingWithElementsAfterRotation {
@@ -76,8 +76,8 @@
   for (NSNumber *orientation in orientations) {
     [EarlGrey rotateDeviceToOrientation:[orientation intValue] errorOrNil:nil];
 
-    XCTAssertTrue([UIDevice currentDevice].orientation == [orientation intValue],
-                  @"Device orientation should match");
+    GREYAssertTrue([UIDevice currentDevice].orientation == [orientation intValue],
+                   @"Device orientation should match");
 
     // Tap clear, check if label was reset
     [[EarlGrey selectElementWithMatcher:grey_text(@"Clear")] performAction:grey_tap()];

--- a/Tests/FunctionalTests/Sources/FTROrientationPortraitOnlyChangeTest.m
+++ b/Tests/FunctionalTests/Sources/FTROrientationPortraitOnlyChangeTest.m
@@ -64,11 +64,11 @@
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationPortrait errorOrNil:nil];
 
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationLandscapeLeft errorOrNil:nil];
-  XCTAssertTrue([UIDevice currentDevice].orientation == UIDeviceOrientationLandscapeLeft,
-                @"Device orientation should now be landscape left");
-  XCTAssertTrue([UIApplication sharedApplication].statusBarOrientation ==
-                UIInterfaceOrientationPortrait,
-                @"Interface orientation should remain portrait");
+  GREYAssertTrue([UIDevice currentDevice].orientation == UIDeviceOrientationLandscapeLeft,
+                 @"Device orientation should now be landscape left");
+  GREYAssertTrue([UIApplication sharedApplication].statusBarOrientation ==
+                 UIInterfaceOrientationPortrait,
+                 @"Interface orientation should remain portrait");
 }
 
 - (void)testDeviceChangeWithoutInterfaceChange {
@@ -77,13 +77,13 @@
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationLandscapeLeft errorOrNil:nil];
   BOOL isStatusBarOrientationPortrait =
       UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation);
-  XCTAssertTrue(isStatusBarOrientationPortrait, @"Status Bar orientation should be Portrait.");
+  GREYAssertTrue(isStatusBarOrientationPortrait, @"Status Bar orientation should be Portrait.");
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationPortrait errorOrNil:nil];
-  XCTAssertTrue([UIDevice currentDevice].orientation == UIDeviceOrientationPortrait,
-                @"Device orientation should now be portrait");
-  XCTAssertTrue([UIApplication sharedApplication].statusBarOrientation ==
-                UIInterfaceOrientationPortrait,
-                @"Interface orientation should remain portrait");
+  GREYAssertTrue([UIDevice currentDevice].orientation == UIDeviceOrientationPortrait,
+                 @"Device orientation should now be portrait");
+  GREYAssertTrue([UIApplication sharedApplication].statusBarOrientation ==
+                 UIInterfaceOrientationPortrait,
+                 @"Interface orientation should remain portrait");
 }
 
 @end

--- a/Tests/FunctionalTests/Sources/FTRScreenshotTest.m
+++ b/Tests/FunctionalTests/Sources/FTRScreenshotTest.m
@@ -90,7 +90,7 @@
 
   CGRect actualRect = CGRectMake(0, 0, screenshot.size.width, screenshot.size.height);
   GREYAssertTrue(CGRectEqualToRect(actualRect, self.grey_expectedImageRectForAppStore),
-               @"Screenshot isn't correct dimension");
+                 @"Screenshot isn't correct dimension");
 }
 
 - (void)testTakeScreenShotForAppStoreInPortraitUpsideDownMode {
@@ -101,7 +101,7 @@
 
   CGRect actualRect = CGRectMake(0, 0, screenshot.size.width, screenshot.size.height);
   GREYAssertTrue(CGRectEqualToRect(actualRect, self.grey_expectedImageRectForAppStore),
-               @"Screenshot isn't correct dimension");
+                 @"Screenshot isn't correct dimension");
 }
 
 - (void)testTakeScreenShotForAppStoreInLandscapeLeftMode {
@@ -112,7 +112,7 @@
 
   CGRect actualRect = CGRectMake(0, 0, screenshot.size.width, screenshot.size.height);
   GREYAssertTrue(CGRectEqualToRect(actualRect, self.grey_expectedImageRectForAppStore),
-               @"Screenshot isn't correct dimension");
+                 @"Screenshot isn't correct dimension");
 }
 
 - (void)testTakeScreenShotForAppStoreInLandscapeRightMode {
@@ -123,7 +123,7 @@
 
   CGRect actualRect = CGRectMake(0, 0, screenshot.size.width, screenshot.size.height);
   GREYAssertTrue(CGRectEqualToRect(actualRect, self.grey_expectedImageRectForAppStore),
-               @"Screenshot isn't correct dimension");
+                 @"Screenshot isn't correct dimension");
 }
 
 #pragma mark - Private

--- a/Tests/FunctionalTests/Sources/FTRScreenshotTest.m
+++ b/Tests/FunctionalTests/Sources/FTRScreenshotTest.m
@@ -45,15 +45,15 @@
   // TODO: Verify the content of the image as well.
   CGSize expectedSize = CGSizeMake(64, 128);
   CGFloat expectedScale = [UIScreen mainScreen].scale;
-  XCTAssertEqual(expectedSize.width, snapshot.size.width);
-  XCTAssertEqual(expectedSize.height, snapshot.size.height);
-  XCTAssertEqual(expectedScale, snapshot.scale);
+  GREYAssertEqual(expectedSize.width, snapshot.size.width, @"should be equal");
+  GREYAssertEqual(expectedSize.height, snapshot.size.height, @"should be equal");
+  GREYAssertEqual(expectedScale, snapshot.scale, @"should be equal");
 
   NSError *error = nil;
   // Snapshot Accessibility Element with zero height should be an error.
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"ElementWithZeroHeight")]
       performAction:grey_snapshot(&snapshot) error:&error];
-  XCTAssertEqualObjects(kGREYInteractionErrorDomain, error.domain);
+  GREYAssertEqualObjects(kGREYInteractionErrorDomain, error.domain, @"should be equal");
 }
 
 - (void)testSnapshotAXElementInLandscapeMode {
@@ -72,15 +72,15 @@
     expectedSize = CGSizeMake(expectedSize.height, expectedSize.width);
   }
   CGFloat expectedScale = [UIScreen mainScreen].scale;
-  XCTAssertEqual(expectedSize.width, snapshot.size.width);
-  XCTAssertEqual(expectedSize.height, snapshot.size.height);
-  XCTAssertEqual(expectedScale, snapshot.scale);
+  GREYAssertEqual(expectedSize.width, snapshot.size.width, @"should be equal");
+  GREYAssertEqual(expectedSize.height, snapshot.size.height, @"should be equal");
+  GREYAssertEqual(expectedScale, snapshot.scale, @"should be equal");
 
   NSError *error = nil;
   // Snapshot Accessibility Element with zero height should be an error.
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"ElementWithZeroHeight")]
       performAction:grey_snapshot(&snapshot) error:&error];
-  XCTAssertEqualObjects(kGREYInteractionErrorDomain, error.domain);
+  GREYAssertEqualObjects(kGREYInteractionErrorDomain, error.domain, @"should be equal");
 }
 
 - (void)testTakeScreenShotForAppStoreInPortraitMode {

--- a/Tests/FunctionalTests/Sources/FTRScrollViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRScrollViewTest.m
@@ -221,24 +221,24 @@
   // Scroll by a fixed amount and verify that the scroll offset has changed by that amount.
   // Go down to (0, 7)
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Infinite Scroll View")]
-   performAction:grey_scrollInDirection(kGREYDirectionDown, 7)];
+      performAction:grey_scrollInDirection(kGREYDirectionDown, 7)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"topTextbox")]
-   assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(0, 7)))];
+      assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(0, 7)))];
   // Go right to (6, 7)
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Infinite Scroll View")]
-   performAction:grey_scrollInDirection(kGREYDirectionRight, 6)];
+      performAction:grey_scrollInDirection(kGREYDirectionRight, 6)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"topTextbox")]
-   assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(6, 7)))];
+      assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(6, 7)))];
   // Go up to (6, 4)
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Infinite Scroll View")]
-   performAction:grey_scrollInDirection(kGREYDirectionUp, 3)];
+      performAction:grey_scrollInDirection(kGREYDirectionUp, 3)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"topTextbox")]
-   assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(6, 4)))];
+      assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(6, 4)))];
   // Go left to (3, 4)
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Infinite Scroll View")]
-   performAction:grey_scrollInDirection(kGREYDirectionLeft, 3)];
+      performAction:grey_scrollInDirection(kGREYDirectionLeft, 3)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"topTextbox")]
-   assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(3, 4)))];
+      assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(3, 4)))];
 }
 
 - (void)testScrollToTopWithZeroXOffset {
@@ -269,7 +269,7 @@
       assertWithMatcher:grey_text(NSStringFromCGPoint(CGPointMake(50, 0)))];
 }
 
-- (void)testScrollingBeyongTheContentViewCausesScrollErrors {
+- (void)testScrollingBeyondTheContentViewCausesScrollErrors {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
       performAction:grey_scrollInDirection(kGREYDirectionDown, 100)];
   NSError *scrollError;
@@ -299,13 +299,6 @@
 
 #pragma mark - Private
 
-// Asserts that the |exception| reason contains the given |subString|.
-- (void)assertExceptionReasonContains:(NSString *)subString withException:(NSException *)exception {
-  NSRange subStringRange = [exception.reason rangeOfString:subString options:0];
-  XCTAssertTrue(subStringRange.location != NSNotFound, @"\"%@\" was not found in \"%@\"",
-                subString, exception.reason);
-}
-
 - (GREYElementMatcherBlock *)matcherForScrolledToEdge:(GREYContentEdge)edge {
   BOOL (^isScrolledToEdge)(id) = ^BOOL(id element) {
     CGPoint contentOffset = [(UIScrollView *)element contentOffset];
@@ -328,21 +321,6 @@
   return [GREYElementMatcherBlock matcherWithMatchesBlock:isScrolledToEdge
                                          descriptionBlock:^(id description) {
     [description appendText:@"matcherForScrolledToEdge"];
-  }];
-}
-
-// Returns a matcher that matches if the text in the given element represents a point close to the
-// |expected| point within the given |accuracy|.
-- (GREYElementMatcherBlock *)matcherTextWithCGPointValue:(CGPoint)expected
-                                                accuracy:(CGFloat)accuracy {
-  BOOL (^matchesValueWithAccuracy)(id) = ^BOOL(id element) {
-    CGPoint actual = CGPointFromString([element text]);
-    return ABS(actual.x - expected.x) <= accuracy && ABS(actual.y - expected.y) <= accuracy;
-  };
-  return [GREYElementMatcherBlock matcherWithMatchesBlock:matchesValueWithAccuracy
-                                         descriptionBlock:^(id<GREYDescription> description) {
-      [description appendText:[NSString stringWithFormat:@"textMatcher(%@ +/- %f)",
-                                                         NSStringFromCGPoint(expected), accuracy]];
   }];
 }
 

--- a/Tests/FunctionalTests/Sources/FTRScrollViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRScrollViewTest.m
@@ -152,8 +152,8 @@
                                 constraints:grey_kindOfClass([UIScrollView class])
                                performBlock:^BOOL(UIScrollView *scrollView,
                                                   NSError *__strong *error) {
-    XCTAssertTrue(scrollView.bounces, @"Bounce must be set or this test is same as"
-                                      @" testScrollToTopWhenAlreadyAtTheTopWithBounce");
+    GREYAssertTrue(scrollView.bounces, @"Bounce must be set or this test is same as"
+                                       @" testScrollToTopWhenAlreadyAtTheTopWithBounce");
     scrollView.bounces = !scrollView.bounces;
     return YES;
   }];
@@ -275,8 +275,8 @@
   NSError *scrollError;
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
       performAction:grey_scrollInDirection(kGREYDirectionUp, 200) error:&scrollError];
-  XCTAssertEqual(scrollError.domain, kGREYScrollErrorDomain);
-  XCTAssertEqual(scrollError.code, kGREYScrollReachedContentEdge);
+  GREYAssertEqualObjects(scrollError.domain, kGREYScrollErrorDomain, @"should be equal");
+  GREYAssertEqual(scrollError.code, kGREYScrollReachedContentEdge, @"should be equal");
 }
 
 - (void)testSetContentOffsetAnimatedYesWaitsForAnimation {

--- a/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
+++ b/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
@@ -104,11 +104,12 @@ class FunctionalTestRigSwiftTests: XCTestCase {
     EarlGrey().selectElementWithMatcher(grey_text("Tab 2")).performAction(grey_tap())
     EarlGrey().selectElementWithMatcher(grey_accessibilityLabel("tab2Container"))
         .performAction(checkHiddenBlock).assertWithMatcher(grey_sufficientlyVisible())
-    var error:NSError?
+    var error: NSError?
     EarlGrey().selectElementWithMatcher(grey_text("Non Existent Element"))
         .performAction(grey_tap(), error:&error)
     if let errorVal = error {
-      XCTAssertTrue(errorVal.domain == kGREYInteractionErrorDomain, "Element Not Found Error")
+      GREYAssertEqual(errorVal.domain, kGREYInteractionErrorDomain,
+                      reason: "Element Not Found Error")
     }
   }
 

--- a/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
+++ b/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
@@ -53,7 +53,7 @@ class FunctionalTestRigSwiftTests: XCTestCase {
     self.openTestView("Web Views")
     EarlGrey().selectElementWithMatcher(grey_accessibilityLabel("loadGoogle"))
       .performAction(grey_tap())
-    var searchButtonMatcher: GREYMatcher = grey_accessibilityHint("Search")
+    let searchButtonMatcher: GREYMatcher = grey_accessibilityHint("Search")
 
     self.waitForWebElementWithName("Search Button", elementMatcher: searchButtonMatcher)
 

--- a/Tests/FunctionalTests/Sources/FTRSyncAPITest.m
+++ b/Tests/FunctionalTests/Sources/FTRSyncAPITest.m
@@ -31,16 +31,21 @@
 }
 
 - (void)testPushAndPopRunLoopModes {
-  XCTAssertNil([[UIApplication sharedApplication] grey_activeRunLoopMode]);
+  GREYAssertNil([[UIApplication sharedApplication] grey_activeRunLoopMode], @"should be nil");
   [[UIApplication sharedApplication] pushRunLoopMode:@"Boo" requester:self];
-  XCTAssertEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Boo");
+  GREYAssertEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Boo",
+                         @"should be equal");
   [[UIApplication sharedApplication] pushRunLoopMode:@"Foo"];
-  XCTAssertEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Foo");
+  GREYAssertEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Foo",
+                         @"should be equal");
   [[UIApplication sharedApplication] popRunLoopMode:@"Foo"];
-  XCTAssertEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Boo");
+  GREYAssertEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Boo",
+                         @"should be equal");
   [[UIApplication sharedApplication] popRunLoopMode:@"Boo" requester:self];
-  XCTAssertNotEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Boo");
-  XCTAssertNotEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Foo");
+  GREYAssertNotEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Boo",
+                            @"should not be equal");
+  GREYAssertNotEqualObjects([[UIApplication sharedApplication] grey_activeRunLoopMode], @"Foo",
+                            @"should not be equal");
 }
 
 - (void)testGREYExecuteSync {

--- a/Tests/FunctionalTests/Sources/FTRUITableViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRUITableViewTest.m
@@ -110,8 +110,8 @@
                                 constraints:grey_kindOfClass([UIScrollView class])
                                performBlock:^BOOL(UIScrollView *scrollView,
                                                   NSError *__strong *error) {
-    XCTAssertTrue(scrollView.bounces, @"Bounce must be set or this test is same as "
-                                      @"testScrollToTopWhenAlreadyAtTheTopWithBounce");
+    GREYAssertTrue(scrollView.bounces, @"Bounce must be set or this test is same as "
+                                       @"testScrollToTopWhenAlreadyAtTheTopWithBounce");
     scrollView.bounces = NO;
     return YES;
   }];
@@ -178,8 +178,8 @@
       usingSearchAction:grey_scrollInDirection(kGREYDirectionDown, 100)
    onElementWithMatcher:grey_kindOfClass([UITableView class])]
       assertWithMatcher:grey_interactable() error:&err];
-  XCTAssertEqualObjects(err.domain, kGREYInteractionErrorDomain);
-  XCTAssertEqual(err.code, kGREYInteractionElementNotFoundErrorCode);
+  GREYAssertEqualObjects(err.domain, kGREYInteractionErrorDomain, @"should be equal");
+  GREYAssertEqual(err.code, kGREYInteractionElementNotFoundErrorCode, @"should be equal");
 
   [[EarlGrey selectElementWithMatcher:grey_kindOfClass([UITableView class])]
       assert:[GREYAssertionBlock assertionWithName:@"offset didn't change"

--- a/Tests/FunctionalTests/Sources/FTRUIWebViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRUIWebViewTest.m
@@ -160,25 +160,25 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
 - (void)testDelegateIsProxyDelegate {
   UIWebView *webView = [[UIWebView alloc] init];
   GREYUIWebViewDelegate *delegate = [webView delegate];
-  XCTAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
+  GREYAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
 }
 
 - (void)testDelegateIsProxyDelegateAfterSettingCustomDelegate {
   UIWebView *webView = [[UIWebView alloc] init];
   webView.delegate = self;
   GREYUIWebViewDelegate *delegate = [webView delegate];
-  XCTAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
+  GREYAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
 
   webView.delegate = self;
   delegate = [webView delegate];
-  XCTAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
+  GREYAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
 }
 
 - (void)testDelegateIsNotNilAfterClearingDelegate {
   UIWebView *webView = [[UIWebView alloc] init];
   webView.delegate = nil;
   GREYUIWebViewDelegate *delegate = [webView delegate];
-  XCTAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
+  GREYAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
 }
 
 - (void)testDelegateIsNotDeallocAfterClearingDelegate {
@@ -186,21 +186,21 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
   __weak GREYUIWebViewDelegate *delegate;
   {
     delegate = [webView delegate];
-    XCTAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
+    GREYAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
     [webView setDelegate:nil];
   }
 
   __weak GREYUIWebViewDelegate *secondDelegate;
   {
     secondDelegate = [webView delegate];
-    XCTAssertTrue([secondDelegate isKindOfClass:[GREYUIWebViewDelegate class]],
-        @"%@", [delegate class]);
+    GREYAssertTrue([secondDelegate isKindOfClass:[GREYUIWebViewDelegate class]],
+                   @"%@", [delegate class]);
     [webView setDelegate:nil];
   }
 
-  XCTAssertNotNil(delegate);
-  XCTAssertNotNil(secondDelegate);
-  XCTAssertNotEqual(delegate, secondDelegate);
+  GREYAssertNotNil(delegate, @"should not be nil");
+  GREYAssertNotNil(secondDelegate, @"should not be nil");
+  GREYAssertNotEqualObjects(delegate, secondDelegate, @"should not be equal");
 }
 
 - (void)testWebViewDeallocClearsAllDelegates {
@@ -218,12 +218,12 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
       secondDelegate = [webView delegate];
       [webView setDelegate:nil];
     }
-    XCTAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
-    XCTAssertTrue([secondDelegate isKindOfClass:[GREYUIWebViewDelegate class]],
-        @"%@", [delegate class]);
+    GREYAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
+    GREYAssertTrue([secondDelegate isKindOfClass:[GREYUIWebViewDelegate class]],
+                   @"%@", [delegate class]);
   }
-  XCTAssertNil(delegate);
-  XCTAssertNil(secondDelegate);
+  GREYAssertNil(delegate, @"should be nil");
+  GREYAssertNil(secondDelegate, @"should be nil");
 }
 
 - (void)testWebViewProxyDelegateClearsOutDeallocedDelegates {
@@ -234,7 +234,7 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
     __autoreleasing id<UIWebViewDelegate> autoRelDelegate = [[FTRUIWebViewTest alloc] init];
     [webView setDelegate:autoRelDelegate];
     delegate = [webView delegate];
-    XCTAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
+    GREYAssertTrue([delegate isKindOfClass:[GREYUIWebViewDelegate class]], @"%@", [delegate class]);
   }
 
   // Should not crash.
@@ -247,12 +247,12 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
   GREYAppState lastState =
       [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:webView];
   BOOL isAsyncRequestPending = ((lastState & kGREYPendingUIWebViewAsyncRequest) != 0);
-  XCTAssertTrue(isAsyncRequestPending);
+  GREYAssertTrue(isAsyncRequestPending, @"should be pending");
 
   [webView stopLoading];
   lastState = [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:webView];
   isAsyncRequestPending = ((lastState & kGREYPendingUIWebViewAsyncRequest) != 0);
-  XCTAssertFalse(isAsyncRequestPending);
+  GREYAssertFalse(isAsyncRequestPending, @"should not be pending");
 }
 
 - (void)testAjaxTrackedWhenAJAXListenerSchemeIsStarting {
@@ -266,7 +266,7 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
   GREYAppState lastState =
       [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:webView];
   BOOL isAsyncRequestPending = ((lastState & kGREYPendingUIWebViewAsyncRequest) != 0);
-  XCTAssertTrue(isAsyncRequestPending);
+  GREYAssertTrue(isAsyncRequestPending, @"should be pending");
 }
 
 - (void)testAjaxUnTrackedWhenAJAXListenerSchemeIsCompleted {
@@ -276,7 +276,7 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
   GREYAppState lastState =
       [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:webView];
   BOOL isAsyncRequestPending = ((lastState & kGREYPendingUIWebViewAsyncRequest) != 0);
-  XCTAssertTrue(isAsyncRequestPending);
+  GREYAssertTrue(isAsyncRequestPending, @"should be pending");
 
   NSURLRequest *req =
       [NSURLRequest requestWithURL:[NSURL URLWithString:@"greyajaxlistener://completed"]];
@@ -286,7 +286,7 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
                   navigationType:UIWebViewNavigationTypeOther];
   lastState = [[GREYAppStateTracker sharedInstance] grey_lastKnownStateForElement:webView];
   isAsyncRequestPending = ((lastState & kGREYPendingUIWebViewAsyncRequest) != 0);
-  XCTAssertFalse(isAsyncRequestPending);
+  GREYAssertFalse(isAsyncRequestPending, @"should not be pending");
 }
 
 @end


### PR DESCRIPTION
1) Add 3 new Objective-C GREYAsserts and 1 Swift GREYAssert that users of XCTAssert would expect
2) Make FunctionalTestRig tests use GREYAsserts everywhere instead of XCTAssert
3) Fix Swift warning in FunctionalTestRig tests. Fixes #171.
4) Fix for UIApplicationDelegate crash where EarlGrey didn't check if it responds to window selector
5) Remove dead code
6) Minor style improvements