### PR TITLE
Update cheatsheet link in README.md to point to the web link [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ configured, take a look at the EarlGrey API and start writing your own tests.
   * [Backward Compatibility](https://github.com/google/EarlGrey/tree/master/docs/backward-compatibility.md)
   * [Install and Run](https://github.com/google/EarlGrey/tree/master/docs/install-and-run.md)
   * [API](https://github.com/google/EarlGrey/tree/master/docs/api.md)
-  * [Cheat Sheet](docs/cheatsheet/cheatsheet.png)
+  * [Cheat Sheet](https://github.com/google/EarlGrey/tree/master/docs/cheatsheet/cheatsheet.png)
 
 ## Getting Help
 


### PR DESCRIPTION
Issue: The README.md cheatsheet link points to a relative link that fails on any docs generator.
Solution: Change it to use a Weblink.