### PR TITLE
SpringBoard matcher fix, use GREYAsserts, cleanup

### DIFF
--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.m
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.m
@@ -218,13 +218,6 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
       gCurrentExecutingTestCase = self;
       [self grey_setStatus:kGREYXCTestCaseStatusUnknown];
 
-      // We create a new, empty, outputs directory for the test method prior to its invocation.
-      NSError *error;
-      BOOL success =
-          [self grey_createDirRemovingExistingDir:[self grey_localizedTestOutputsDirectory]
-                                            error:&error];
-
-      NSAssert(success, @"Failed to create localized outputs directory with error: %@", error);
       INVOKE_ORIGINAL_IMP(void, @selector(grey_invokeTest));
 
       // The test may have been marked as failed if a failure was recorded with the
@@ -233,7 +226,7 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
       if ([self grey_status] != kGREYXCTestCaseStatusFailed) {
         [self grey_setStatus:kGREYXCTestCaseStatusPassed];
       }
-    } @catch(NSException *exception) {
+    } @catch (NSException *exception) {
       [self grey_setStatus:kGREYXCTestCaseStatusFailed];
       if (![exception.name isEqualToString:kInternalTestInterruptException]) {
         @throw;

--- a/EarlGrey/Core/GREYAutomationSetup.m
+++ b/EarlGrey/Core/GREYAutomationSetup.m
@@ -106,7 +106,7 @@
 #pragma mark - Crash Handlers
 
 // Call only asynchronous-safe functions within signal handlers
-// See definition here: https://www.securecoding.cert.org/confluence/display/seccode/BB.+Definitions
+// Learn more: https://www.securecoding.cert.org/confluence/display/c/SIG00-C.+Mask+signals+handled+by+noninterruptible+signal+handlers
 static void grey_signalHandler(int signal) {
   char *signalString = strsignal(signal);
   write(STDERR_FILENO, signalString, strlen(signalString));
@@ -130,7 +130,7 @@ static void grey_installSignalHandler(int signalId, struct sigaction *handler) {
   }
 }
 
-+ (void) grey_setupCrashHandlers {
++ (void)grey_setupCrashHandlers {
   NSLog(@"Crash handler setup started.");
 
   struct sigaction signalActionHandler;

--- a/EarlGrey/EarlGrey.m
+++ b/EarlGrey/EarlGrey.m
@@ -21,13 +21,9 @@
 #import "Additions/XCTestCase+GREYAdditions.h"
 #import "Common/GREYAnalytics.h"
 #import "Common/GREYConfiguration.h"
-#import "Common/GREYDefines.h"
-#import "Common/GREYExposed.h"
 #import "Core/GREYAutomationSetup.h"
-#import "Core/GREYKeyboard.h"
 #import "Event/GREYSyntheticEvents.h"
 #import "Exception/GREYDefaultFailureHandler.h"
-#import "Synchronization/GREYUIThreadExecutor.h"
 
 // Handler for all EarlGrey failures.
 id<GREYFailureHandler> greyFailureHandler;

--- a/EarlGrey/Matcher/GREYMatchers.m
+++ b/EarlGrey/Matcher/GREYMatchers.m
@@ -184,7 +184,8 @@ static const double kElementSufficientlyVisiblePercentage = 0.75;
 
 + (id<GREYMatcher>)matcherForSystemAlertViewShown {
   MatchesBlock matches = ^BOOL(id element) {
-    return [[UIApplication sharedApplication] _isSpringBoardShowingAnAlert];
+    return [[UIApplication sharedApplication] _isSpringBoardShowingAnAlert] &&
+           ![[[NSBundle mainBundle] bundleIdentifier] isEqualToString:@"com.apple.springboard"];
   };
   DescribeToBlock describe = ^void(id<GREYDescription> description) {
     [description appendText:@"isSystemAlertViewShown"];

--- a/Tests/FunctionalTests/Sources/FTRAccessibilityTest.m
+++ b/Tests/FunctionalTests/Sources/FTRAccessibilityTest.m
@@ -116,7 +116,7 @@
     // Square element rect is {50, 150, 100, 100}
     [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"SquareElementLabel")]
         performAction:grey_tapAtPoint(CGPointMake(-51, -151))];
-    XCTFail(@"Should throw an exception");
+    GREYFail(@"Should throw an exception");
   } @catch (NSException *exception) {
     NSRange exceptionRange = [[exception reason] rangeOfString:@"Action 'Tap' failed."];
     GREYAssertNotEqual(exceptionRange.location, NSNotFound, @"should not be equal");

--- a/Tests/FunctionalTests/Sources/FTRBaseIntegrationTest.h
+++ b/Tests/FunctionalTests/Sources/FTRBaseIntegrationTest.h
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-// Base test class for all earl grey integration test.
+// Base test class for all EarlGrey integration tests.
 @interface FTRBaseIntegrationTest : XCTestCase
 
 - (void)openTestViewNamed:(NSString *)name;

--- a/Tests/FunctionalTests/Sources/FTRBaseIntegrationTest.m
+++ b/Tests/FunctionalTests/Sources/FTRBaseIntegrationTest.m
@@ -16,7 +16,6 @@
 
 #import "FTRBaseIntegrationTest.h"
 
-#import "FTRMainViewController.h"
 #import "FTRNetworkProxy.h"
 
 @implementation FTRBaseIntegrationTest {

--- a/Tests/FunctionalTests/Sources/FTRBasicInteractionTest.m
+++ b/Tests/FunctionalTests/Sources/FTRBasicInteractionTest.m
@@ -69,7 +69,7 @@
   [[EarlGrey selectElementWithMatcher:grey_keyWindow()] performAction:[GREYActions actionForTap]];
 
   UITapGestureRecognizer *tapGestureRecognizer =
-      [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissWindow:)];
+      [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(ftr_dismissWindow:)];
   tapGestureRecognizer.numberOfTapsRequired = 1;
 
   // Create a custom window that dismisses itself when tapped.
@@ -86,10 +86,6 @@
 
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TopMostWindow")]
       assertWithMatcher:grey_notVisible()];
-}
-
-- (void)dismissWindow:(UITapGestureRecognizer *)sender {
-  [sender.view setHidden:YES];
 }
 
 - (void)testRootViewControllerSetMultipleTimesOnMainWindow {
@@ -350,6 +346,12 @@
       performAction:makeWindowOpaqueBlock];
   [[EarlGrey selectElementWithMatcher:[GREYMatchers matcherForAccessibilityLabel:@"Long Press"]]
       assertWithMatcher:grey_sufficientlyVisible()];
+}
+
+#pragma mark - Private
+
+- (void)ftr_dismissWindow:(UITapGestureRecognizer *)sender {
+  [sender.view setHidden:YES];
 }
 
 @end

--- a/Tests/FunctionalTests/Sources/FTRCollectionViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRCollectionViewTest.m
@@ -26,25 +26,6 @@
   [self openTestViewNamed:@"Collection Views"];
 }
 
-- (void)verifyTapOnChar:(char)ch {
-  NSString *previous = [NSString stringWithFormat:@"%c", ch];
-  NSString *next = [NSString stringWithFormat:@"%d", toupper(ch)];
-  [[EarlGrey selectElementWithMatcher:grey_text(previous)] performAction:grey_tap()];
-  [EarlGrey selectElementWithMatcher:grey_text(next)];
-}
-
-// Scrolls the test CollectionView containing alphabets in the given |direction| until the given
-// char is interactable.
-- (void)scrollInDirection:(GREYDirection)direction untilInteractableWithChar:(char)aChar {
-  // Spelling these out separately to align the following code properly making it more readable.
-  id<GREYMatcher> charMatcher = grey_text([NSString stringWithFormat:@"%c", aChar]);
-  id<GREYAction> scrollAction = grey_scrollInDirection(direction, 50);
-  id<GREYMatcher> searchActionElementMatcher = grey_accessibilityID(@"Alphabets");
-  [[[EarlGrey selectElementWithMatcher:grey_allOf(charMatcher, grey_interactable(), nil)]
-      usingSearchAction:scrollAction onElementWithMatcher:searchActionElementMatcher]
-      assertWithMatcher:grey_interactable()];
-}
-
 - (void)testSearchActionWithCollectionViewHorizontalLayout {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"layoutPicker")]
       performAction:[GREYActions actionForSetPickerColumn:0 toValue:@"Horizontal Layout"]];
@@ -56,16 +37,16 @@
   // This test will search and find A, B, C, X, Y and Z and tap them.
 
   // Scroll to left to find A, B and C.
-  [self scrollInDirection:kGREYDirectionLeft untilInteractableWithChar:'A'];
-  [self verifyTapOnChar:'A'];
-  [self verifyTapOnChar:'B'];
-  [self verifyTapOnChar:'C'];
+  [self ftr_scrollInDirection:kGREYDirectionLeft untilInteractableWithChar:'A'];
+  [self ftr_verifyTapOnChar:'A'];
+  [self ftr_verifyTapOnChar:'B'];
+  [self ftr_verifyTapOnChar:'C'];
 
   // Scroll to right to find X Y and Z.
-  [self scrollInDirection:kGREYDirectionRight untilInteractableWithChar:'Z'];
-  [self verifyTapOnChar:'X'];
-  [self verifyTapOnChar:'Y'];
-  [self verifyTapOnChar:'Z'];
+  [self ftr_scrollInDirection:kGREYDirectionRight untilInteractableWithChar:'Z'];
+  [self ftr_verifyTapOnChar:'X'];
+  [self ftr_verifyTapOnChar:'Y'];
+  [self ftr_verifyTapOnChar:'Z'];
 }
 
 - (void)testSearchActionWithCollectionViewVerticalLayout {
@@ -80,16 +61,16 @@
   // This test will search and find A, B, C, X, Y and Z and tap them.
 
   // Scroll to top to find A, B and C.
-  [self scrollInDirection:kGREYDirectionUp untilInteractableWithChar:'A'];
-  [self verifyTapOnChar:'A'];
-  [self verifyTapOnChar:'B'];
-  [self verifyTapOnChar:'C'];
+  [self ftr_scrollInDirection:kGREYDirectionUp untilInteractableWithChar:'A'];
+  [self ftr_verifyTapOnChar:'A'];
+  [self ftr_verifyTapOnChar:'B'];
+  [self ftr_verifyTapOnChar:'C'];
 
   // Scroll to bottom to find X, Y and Z.
-  [self scrollInDirection:kGREYDirectionDown untilInteractableWithChar:'Z'];
-  [self verifyTapOnChar:'X'];
-  [self verifyTapOnChar:'Y'];
-  [self verifyTapOnChar:'Z'];
+  [self ftr_scrollInDirection:kGREYDirectionDown untilInteractableWithChar:'Z'];
+  [self ftr_verifyTapOnChar:'X'];
+  [self ftr_verifyTapOnChar:'Y'];
+  [self ftr_verifyTapOnChar:'Z'];
 }
 
 - (void)testSearchActionWithCollectionViewCustomLayout {
@@ -104,22 +85,44 @@
   // This test will search and find A, B, C, X, Y and Z and tap them.
 
   // Scroll to top left for A, B and C.
-  [self scrollInDirection:kGREYDirectionLeft untilInteractableWithChar:'A'];
-  [self verifyTapOnChar:'A'];
-  [self verifyTapOnChar:'B'];
-  [self verifyTapOnChar:'C'];
+  [self ftr_scrollInDirection:kGREYDirectionLeft untilInteractableWithChar:'A'];
+  [self ftr_verifyTapOnChar:'A'];
+  [self ftr_verifyTapOnChar:'B'];
+  [self ftr_verifyTapOnChar:'C'];
 
   // Scroll to bottom to find Z.
-  [self scrollInDirection:kGREYDirectionDown untilInteractableWithChar:'Z'];
+  [self ftr_scrollInDirection:kGREYDirectionDown untilInteractableWithChar:'Z'];
 
   // Scroll to bottom-right to find X and tap it.
-  [self scrollInDirection:kGREYDirectionRight untilInteractableWithChar:'X'];
-  [self verifyTapOnChar:'X'];
+  [self ftr_scrollInDirection:kGREYDirectionRight untilInteractableWithChar:'X'];
+  [self ftr_verifyTapOnChar:'X'];
 
   // Scroll to bottom-left to find Y and Z.
-  [self scrollInDirection:kGREYDirectionLeft untilInteractableWithChar:'Y'];
-  [self verifyTapOnChar:'Y'];
-  [self verifyTapOnChar:'Z'];
+  [self ftr_scrollInDirection:kGREYDirectionLeft untilInteractableWithChar:'Y'];
+  [self ftr_verifyTapOnChar:'Y'];
+  [self ftr_verifyTapOnChar:'Z'];
+}
+
+#pragma mark - Private
+
+- (void)ftr_verifyTapOnChar:(char)ch {
+  NSString *previous = [NSString stringWithFormat:@"%c", ch];
+  NSString *next = [NSString stringWithFormat:@"%d", toupper(ch)];
+  [[EarlGrey selectElementWithMatcher:grey_text(previous)] performAction:grey_tap()];
+  [EarlGrey selectElementWithMatcher:grey_text(next)];
+}
+
+// Scrolls the test CollectionView containing alphabets in the given |direction| until the given
+// char is interactable.
+- (void)ftr_scrollInDirection:(GREYDirection)direction untilInteractableWithChar:(char)aChar {
+  // Spelling these out separately to align the following code properly making it more readable.
+  id<GREYMatcher> charMatcher = grey_text([NSString stringWithFormat:@"%c", aChar]);
+  id<GREYAction> scrollAction = grey_scrollInDirection(direction, 50);
+  id<GREYMatcher> searchActionElementMatcher = grey_accessibilityID(@"Alphabets");
+  [[[EarlGrey selectElementWithMatcher:grey_allOf(charMatcher, grey_interactable(), nil)]
+      usingSearchAction:scrollAction onElementWithMatcher:searchActionElementMatcher]
+      assertWithMatcher:grey_interactable()];
 }
 
 @end
+

--- a/Tests/FunctionalTests/Sources/FTRGestureTest.m
+++ b/Tests/FunctionalTests/Sources/FTRGestureTest.m
@@ -115,40 +115,23 @@
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
-// Asserts that the given gesture has been recognised regardless of the gesture's start point.
-- (void)grey_assertGestureRecognized:(NSString *)gesture {
-  MatchesBlock gestureMatcherBlock = ^BOOL (id element) {
-    NSString *text = [(UILabel *)element text];
-    GREYAssert([text hasPrefix:gesture], @"Gesture prefix '%@' not found in '%@'.", gesture, text);
-    return YES;
-  };
-  DescribeToBlock gestureMatcherDescriptionBlock = ^(id<GREYDescription> description) {
-    [description appendText:@"Gesture Matcher"];
-  };
-  GREYElementMatcherBlock *gestureElementMatcher =
-      [[GREYElementMatcherBlock alloc] initWithMatchesBlock:gestureMatcherBlock
-                                           descriptionBlock:gestureMatcherDescriptionBlock];
-  [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"gesture")]
-      assertWithMatcher:gestureElementMatcher];
-}
-
 - (void)testSwipeWorksInAllDirectionsInPortraitMode {
-  [self assertSwipeWorksInAllDirections];
+  [self ftr_assertSwipeWorksInAllDirections];
 }
 
 - (void)testSwipeWorksInAllDirectionsInUpsideDownMode {
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationPortraitUpsideDown errorOrNil:nil];
-  [self assertSwipeWorksInAllDirections];
+  [self ftr_assertSwipeWorksInAllDirections];
 }
 
 - (void)testSwipeWorksInAllDirectionsInLandscapeLeftMode {
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationLandscapeLeft errorOrNil:nil];
-  [self assertSwipeWorksInAllDirections];
+  [self ftr_assertSwipeWorksInAllDirections];
 }
 
 - (void)testSwipeWorksInAllDirectionsInLandscapeRightMode {
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationLandscapeRight errorOrNil:nil];
-  [self assertSwipeWorksInAllDirections];
+  [self ftr_assertSwipeWorksInAllDirections];
 }
 
 - (void)testSwipeOnWindow {
@@ -199,19 +182,37 @@
 
 // Asserts that Swipe works in all directions by verifying if the swipe gestures are correctly
 // recognized.
-- (void)assertSwipeWorksInAllDirections {
+- (void)ftr_assertSwipeWorksInAllDirections {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Grey Box")]
       performAction:grey_swipeFastInDirection(kGREYDirectionUp)];
-  [self grey_assertGestureRecognized:@"swipe up"];
+  [self ftr_assertGestureRecognized:@"swipe up"];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Grey Box")]
       performAction:grey_swipeSlowInDirection(kGREYDirectionDown)];
-  [self grey_assertGestureRecognized:@"swipe down"];
+  [self ftr_assertGestureRecognized:@"swipe down"];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Grey Box")]
       performAction:grey_swipeFastInDirection(kGREYDirectionLeft)];
-  [self grey_assertGestureRecognized:@"swipe left"];
+  [self ftr_assertGestureRecognized:@"swipe left"];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Grey Box")]
       performAction:grey_swipeSlowInDirection(kGREYDirectionRight)];
-  [self grey_assertGestureRecognized:@"swipe right"];
+  [self ftr_assertGestureRecognized:@"swipe right"];
+}
+
+// Asserts that the given gesture has been recognised regardless of the gesture's start point.
+- (void)ftr_assertGestureRecognized:(NSString *)gesture {
+  MatchesBlock gestureMatcherBlock = ^BOOL (id element) {
+    NSString *text = [(UILabel *)element text];
+    GREYAssert([text hasPrefix:gesture], @"Gesture prefix '%@' not found in '%@'.", gesture, text);
+    return YES;
+  };
+  DescribeToBlock gestureMatcherDescriptionBlock = ^(id<GREYDescription> description) {
+    [description appendText:@"Gesture Matcher"];
+  };
+  GREYElementMatcherBlock *gestureElementMatcher =
+      [[GREYElementMatcherBlock alloc] initWithMatchesBlock:gestureMatcherBlock
+                                           descriptionBlock:gestureMatcherDescriptionBlock];
+  [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"gesture")]
+      assertWithMatcher:gestureElementMatcher];
 }
 
 @end
+

--- a/Tests/FunctionalTests/Sources/FTRKeyboardKeysTest.m
+++ b/Tests/FunctionalTests/Sources/FTRKeyboardKeysTest.m
@@ -137,7 +137,7 @@
   @try {
     [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"NonTypingTextField")]
         performAction:[GREYActions actionForTypeText:@"Should Fail"]];
-    XCTFail(@"Should throw an exception");
+    GREYFail(@"Should throw an exception");
   } @catch (NSException *exception) {
     NSRange exceptionRange =
         [[exception reason] rangeOfString:@"Action 'Type \"Should Fail\"' failed."];

--- a/Tests/FunctionalTests/Sources/FTRKeyboardKeysTest.m
+++ b/Tests/FunctionalTests/Sources/FTRKeyboardKeysTest.m
@@ -37,21 +37,21 @@
 - (void)testTypingAtBeginning {
   [[[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
       performAction:[GREYActions actionForTypeText:@"Foo"]]
-      performAction:[self grey_actionForTypingText:@"Bar" atPosition:0]]
+      performAction:[self ftr_actionForTypingText:@"Bar" atPosition:0]]
       assertWithMatcher:grey_text(@"BarFoo")];
 }
 
 - (void)testTypingAtEnd {
     [[[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
       performAction:[GREYActions actionForTypeText:@"Foo"]]
-      performAction:[self grey_actionForTypingText:@"Bar" atPosition:-1]]
+      performAction:[self ftr_actionForTypingText:@"Bar" atPosition:-1]]
       assertWithMatcher:grey_text(@"FooBar")];
 }
 
 - (void)testTypingInMiddle {
   [[[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
       performAction:[GREYActions actionForTypeText:@"Foo"]]
-      performAction:[self grey_actionForTypingText:@"Bar" atPosition:2]]
+      performAction:[self ftr_actionForTypingText:@"Bar" atPosition:2]]
       assertWithMatcher:grey_text(@"FoBaro")];
 }
 
@@ -59,7 +59,7 @@
   [[[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
       performAction:
           [GREYActions actionForTypeText:@"This string is a little too long for this text field!"]]
-      performAction:[self grey_actionForTypingText:@"Foo" atPosition:1]]
+      performAction:[self ftr_actionForTypingText:@"Foo" atPosition:1]]
       assertWithMatcher:grey_text(@"TFoohis string is a little too long for this text field!")];
 }
 
@@ -147,74 +147,74 @@
 
 - (void)testTypingWordsThatTriggerAutoCorrect {
   NSString *string = @"hekp";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
       performAction:grey_clearText()];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextView")]
       performAction:grey_clearText()];
 
   string = @"helko";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
       performAction:grey_clearText()];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextView")]
       performAction:grey_clearText()];
 
   string = @"balk";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
       performAction:grey_clearText()];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextView")]
       performAction:grey_clearText()];
 
   string = @"surr";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testNumbersTyping {
   NSString *string = @"1234567890";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testSymbolsTyping {
   NSString *string = @"~!@#$%^&*()_+-={}:;<>?";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testLetterTyping {
   NSString *string = @"aBc";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testEmailTyping {
   NSString *string = @"donec.metus+spam@google.com";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testUpperCaseLettersTyping {
   NSString *string = @"VERYLONGTEXTWITHMANYLETTERS";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testNumbersAndSpacesTyping {
   NSString *string = @"0 1 2 3 4 5 6 7 8 9";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testSymbolsAndSpacesTyping {
   NSString *string = @"[ ] # + = _ < > { }";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testSpaceKey {
   NSString *string = @"a b";
-  [self typeString:string andVerifyOutput:string];
+  [self ftr_typeString:string andVerifyOutput:string];
 }
 
 - (void)testBackspaceKey {
   NSString *string = @"ab\b";
   NSString *verificationString = @"a";
-  [self typeString:string andVerifyOutput:verificationString];
+  [self ftr_typeString:string andVerifyOutput:verificationString];
 }
 
 - (void)testReturnKey {
@@ -262,20 +262,6 @@
   NSString *string = @"a1a%a%1%";
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
       performAction:grey_typeText(string)];
-}
-
-- (void)typeString:(NSString *)string andVerifyOutput:(NSString *)verificationString {
-  [[[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
-      performAction:grey_typeText(string)]
-      performAction:grey_typeText(@"\n")]
-      assertWithMatcher:grey_text(verificationString)];
-
-  [[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextView")]
-      performAction:grey_typeText(string)]
-      assertWithMatcher:grey_text(verificationString)];
-
-  [[EarlGrey selectElementWithMatcher:grey_buttonTitle(@"Done")]
-      performAction:grey_tap()];
 }
 
 - (void)testKeyplaneIsDetectedCorrectlyWhenSwitchingTextFields {
@@ -453,8 +439,20 @@
 
 #pragma mark - Private
 
+- (void)ftr_typeString:(NSString *)string andVerifyOutput:(NSString *)verificationString {
+  [[[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
+      performAction:grey_typeText(string)]
+      performAction:grey_typeText(@"\n")]
+      assertWithMatcher:grey_text(verificationString)];
+  [[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextView")]
+      performAction:grey_typeText(string)]
+      assertWithMatcher:grey_text(verificationString)];
+  [[EarlGrey selectElementWithMatcher:grey_buttonTitle(@"Done")]
+      performAction:grey_tap()];
+}
+
 // Helper action that converts numeric position to UITextPosition.
-- (id<GREYAction>)grey_actionForTypingText:(NSString *)text atPosition:(NSInteger)position {
+- (id<GREYAction>)ftr_actionForTypingText:(NSString *)text atPosition:(NSInteger)position {
   NSString *actionName =
       [NSString stringWithFormat:@"Test type \"%@\" at position %ld", text, (long)position];
   return [GREYActionBlock actionWithName:actionName

--- a/Tests/FunctionalTests/Sources/FTRLocalUIWebViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRLocalUIWebViewTest.m
@@ -73,7 +73,7 @@
       usingSearchAction:grey_scrollInDirection(kGREYDirectionDown, 200)
       onElementWithMatcher:grey_kindOfClass([UIWebView class])]
       performAction:grey_tap()];
-  [self waitForWebElementWithName:@"APPS" elementMatcher:grey_accessibilityLabel(@"APPS")];
+  [self ftr_waitForWebElementWithName:@"APPS" elementMatcher:grey_accessibilityLabel(@"APPS")];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"APPS")]
       assertWithMatcher:grey_sufficientlyVisible()];
 }
@@ -82,12 +82,12 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"loadGoogle")]
       performAction:grey_tap()];
   id<GREYMatcher> searchButtonMatcher = grey_accessibilityHint(@"Search");
-  [self waitForWebElementWithName:@"Search Button" elementMatcher:searchButtonMatcher];
+  [self ftr_waitForWebElementWithName:@"Search Button" elementMatcher:searchButtonMatcher];
   [[[EarlGrey selectElementWithMatcher:searchButtonMatcher]
       performAction:grey_clearText()]
       performAction:grey_typeText(@"20 + 22\n")];
 
-  [self waitForWebElementWithName:@"Search Button" elementMatcher:grey_accessibilityLabel(@"42")];
+  [self ftr_waitForWebElementWithName:@"Search Button" elementMatcher:grey_accessibilityLabel(@"42")];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"42")]
       assertWithMatcher:grey_sufficientlyVisible()];
 
@@ -104,7 +104,7 @@
   id<GREYMatcher> resultMatcher = grey_allOf(grey_accessibilityLabel(@"George Lucas"),
                                              grey_accessibilityTrait(UIAccessibilityTraitHeader),
                                              nil);
-  [self waitForWebElementWithName:@"Search Result" elementMatcher:resultMatcher];
+  [self ftr_waitForWebElementWithName:@"Search Result" elementMatcher:resultMatcher];
   [[EarlGrey selectElementWithMatcher:resultMatcher] assertWithMatcher:grey_sufficientlyVisible()];
 }
 
@@ -145,7 +145,7 @@
  *  @param name    Name of the element to wait for.
  *  @param matcher Matcher that uniquely matches the element to wait for.
  */
-- (void)waitForWebElementWithName:(NSString *)name elementMatcher:(id<GREYMatcher>)matcher {
+- (void)ftr_waitForWebElementWithName:(NSString *)name elementMatcher:(id<GREYMatcher>)matcher {
   // TODO: Improve EarlGrey webview synchronization so that it automatically waits for the page to
   // load removing the need for conditions such as this.
   [[GREYCondition conditionWithName:[name stringByAppendingString:@" Condition"]

--- a/Tests/FunctionalTests/Sources/FTRScreenshotTest.m
+++ b/Tests/FunctionalTests/Sources/FTRScreenshotTest.m
@@ -89,7 +89,7 @@
   GREYAssert(screenshot, @"Failed to take screenshot");
 
   CGRect actualRect = CGRectMake(0, 0, screenshot.size.width, screenshot.size.height);
-  GREYAssertTrue(CGRectEqualToRect(actualRect, self.grey_expectedImageRectForAppStore),
+  GREYAssertTrue(CGRectEqualToRect(actualRect, [self ftr_expectedImageRectForAppStore]),
                  @"Screenshot isn't correct dimension");
 }
 
@@ -100,7 +100,7 @@
   GREYAssert(screenshot, @"Failed to take screenshot");
 
   CGRect actualRect = CGRectMake(0, 0, screenshot.size.width, screenshot.size.height);
-  GREYAssertTrue(CGRectEqualToRect(actualRect, self.grey_expectedImageRectForAppStore),
+  GREYAssertTrue(CGRectEqualToRect(actualRect, [self ftr_expectedImageRectForAppStore]),
                  @"Screenshot isn't correct dimension");
 }
 
@@ -111,7 +111,7 @@
   GREYAssert(screenshot, @"Failed to take screenshot");
 
   CGRect actualRect = CGRectMake(0, 0, screenshot.size.width, screenshot.size.height);
-  GREYAssertTrue(CGRectEqualToRect(actualRect, self.grey_expectedImageRectForAppStore),
+  GREYAssertTrue(CGRectEqualToRect(actualRect, [self ftr_expectedImageRectForAppStore]),
                  @"Screenshot isn't correct dimension");
 }
 
@@ -122,13 +122,13 @@
   GREYAssert(screenshot, @"Failed to take screenshot");
 
   CGRect actualRect = CGRectMake(0, 0, screenshot.size.width, screenshot.size.height);
-  GREYAssertTrue(CGRectEqualToRect(actualRect, self.grey_expectedImageRectForAppStore),
+  GREYAssertTrue(CGRectEqualToRect(actualRect, [self ftr_expectedImageRectForAppStore]),
                  @"Screenshot isn't correct dimension");
 }
 
 #pragma mark - Private
 
-- (CGRect)grey_expectedImageRectForAppStore {
+- (CGRect)ftr_expectedImageRectForAppStore {
   CGRect screenRect = [UIScreen mainScreen].bounds;
   UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
 

--- a/Tests/FunctionalTests/Sources/FTRScrollViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRScrollViewTest.m
@@ -40,19 +40,19 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeTop]];
 }
 
 - (void)testScrollToBottomEdge {
   [[[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeBottom)]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeBottom]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeBottom]];
 }
 
 - (void)testScrollToRightEdge {
   [[[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeRight)]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeRight]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeRight]];
 }
 
 - (void)testScrollToLeftEdge {
@@ -60,35 +60,35 @@
       performAction:grey_scrollToContentEdge(kGREYContentEdgeRight)];
   [[[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeLeft)]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeLeft]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeLeft]];
 }
 
 - (void)testScrollToLeftEdgeWithCustomStartPoint {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
       performAction:grey_scrollToContentEdgeWithStartPoint(kGREYContentEdgeLeft, 0.5, 0.5)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeLeft]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeLeft]];
 }
 
 - (void)testScrollToRightEdgeWithCustomStartPoint {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
       performAction:grey_scrollToContentEdgeWithStartPoint(kGREYContentEdgeRight, 0.5, 0.5)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeRight]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeRight]];
 }
 
 - (void)testScrollToTopEdgeWithCustomStartPoint {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
       performAction:grey_scrollToContentEdgeWithStartPoint(kGREYContentEdgeTop, 0.5, 0.5)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeTop]];
 }
 
 - (void)testScrollToBottomEdgeWithCustomStartPoint {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
       performAction:grey_scrollToContentEdgeWithStartPoint(kGREYContentEdgeBottom, 0.5, 0.5)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Bottom Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeBottom]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeBottom]];
 }
 
 - (void)testScrollToTopWorksWithPositiveInsets {
@@ -112,7 +112,7 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeTop]];
 }
 
 - (void)testScrollToTopWorksWithNegativeInsets {
@@ -134,7 +134,7 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeTop]];
 }
 
 - (void)testSearchActionReturnsNilWhenElementIsNotFound {
@@ -163,7 +163,7 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeTop]];
 }
 
 - (void)testScrollToTopWhenAlreadyAtTheTopWithBounce {
@@ -171,7 +171,7 @@
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
 
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
-      assertWithMatcher:[self matcherForScrolledToEdge:kGREYContentEdgeTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToEdge:kGREYContentEdgeTop]];
 }
 
 - (void)testVisibilityOnPartiallyObscuredScrollView {
@@ -199,22 +199,22 @@
 }
 
 - (void)testScrollInDirectionCausesExactChangesToContentOffsetInPortraitMode {
-  [self assertScrollInDirectionCausesExactChangesToContentOffset];
+  [self ftr_assertScrollInDirectionCausesExactChangesToContentOffset];
 }
 
 - (void)testScrollInDirectionCausesExactChangesToContentOffsetInPortraitUpsideDownMode {
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationPortraitUpsideDown errorOrNil:nil];
-  [self assertScrollInDirectionCausesExactChangesToContentOffset];
+  [self ftr_assertScrollInDirectionCausesExactChangesToContentOffset];
 }
 
 - (void)testScrollInDirectionCausesExactChangesToContentOffsetInLandscapeLeftMode {
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationLandscapeLeft errorOrNil:nil];
-  [self assertScrollInDirectionCausesExactChangesToContentOffset];
+  [self ftr_assertScrollInDirectionCausesExactChangesToContentOffset];
 }
 
 - (void)testScrollInDirectionCausesExactChangesToContentOffsetInLandscapeRightMode {
   [EarlGrey rotateDeviceToOrientation:UIDeviceOrientationLandscapeRight errorOrNil:nil];
-  [self assertScrollInDirectionCausesExactChangesToContentOffset];
+  [self ftr_assertScrollInDirectionCausesExactChangesToContentOffset];
 }
 
 - (void)testScrollInDirectionCausesExactChangesToContentOffsetWithTinyScrollAmounts {
@@ -280,26 +280,26 @@
 }
 
 - (void)testSetContentOffsetAnimatedYesWaitsForAnimation {
-  [self setContentOffSet:CGPointMake(0, 100) animated:YES];
+  [self ftr_setContentOffSet:CGPointMake(0, 100) animated:YES];
 
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"SquareElementLabel")]
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
 - (void)testSetContentOffsetAnimatedNoDoesNotWaitForAnimation {
-  [self setContentOffSet:CGPointMake(0, 100) animated:NO];
+  [self ftr_setContentOffSet:CGPointMake(0, 100) animated:NO];
 
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"SquareElementLabel")]
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
 - (void)testSetContentOffsetToSameCGPointDoesNotWait{
-  [self setContentOffSet:CGPointZero animated:YES];
+  [self ftr_setContentOffSet:CGPointZero animated:YES];
 }
 
 #pragma mark - Private
 
-- (GREYElementMatcherBlock *)matcherForScrolledToEdge:(GREYContentEdge)edge {
+- (GREYElementMatcherBlock *)ftr_matcherForScrolledToEdge:(GREYContentEdge)edge {
   BOOL (^isScrolledToEdge)(id) = ^BOOL(id element) {
     CGPoint contentOffset = [(UIScrollView *)element contentOffset];
     UIEdgeInsets contentInset = [(UIScrollView *)element contentInset];
@@ -320,13 +320,13 @@
   };
   return [GREYElementMatcherBlock matcherWithMatchesBlock:isScrolledToEdge
                                          descriptionBlock:^(id description) {
-    [description appendText:@"matcherForScrolledToEdge"];
+    [description appendText:@"ftr_matcherForScrolledToEdge"];
   }];
 }
 
 // Asserts that the scroll actions work accurately in all four directions by verifying the content
 // offset changes caused by them.
-- (void)assertScrollInDirectionCausesExactChangesToContentOffset {
+- (void)ftr_assertScrollInDirectionCausesExactChangesToContentOffset {
   // Scroll by a fixed amount and verify that the scroll offset has changed by that amount.
   // Go down to (0, 99)
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"Infinite Scroll View")]
@@ -351,14 +351,14 @@
 }
 
 // Makes a setContentOffset:animated: call on an element of type UIScrollView.
-- (void)setContentOffSet:(CGPoint)offset animated:(BOOL)animated {
+- (void)ftr_setContentOffSet:(CGPoint)offset animated:(BOOL)animated {
   BOOL (^actionBlock)(UIScrollView *, __strong NSError **) =
       ^BOOL (UIScrollView *view, __strong NSError **errorOrNil) {
           [view setContentOffset:offset animated:animated];
           return YES;
         };
 
-  id<GREYAction> action = [GREYActionBlock actionWithName:@"setContentOffSet"
+  id<GREYAction> action = [GREYActionBlock actionWithName:@"ftr_setContentOffSet"
                                               constraints:grey_kindOfClass([UIScrollView class])
                                              performBlock:actionBlock];
 

--- a/Tests/FunctionalTests/Sources/FTRUITableViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRUITableViewTest.m
@@ -41,33 +41,33 @@
 }
 
 - (void)testSearchActionWithTinyScrollIncrements {
-  [[self scrollToCellAtIndex:20 byScrollingInAmounts:50 InDirection:kGREYDirectionDown]
+  [[self ftr_scrollToCellAtIndex:20 byScrollingInAmounts:50 InDirection:kGREYDirectionDown]
       assertWithMatcher:grey_notNil()];
-  [[self scrollToCellAtIndex:0 byScrollingInAmounts:50 InDirection:kGREYDirectionUp]
+  [[self ftr_scrollToCellAtIndex:0 byScrollingInAmounts:50 InDirection:kGREYDirectionUp]
       assertWithMatcher:grey_notNil()];
-  [[self scrollToCellAtIndex:20 byScrollingInAmounts:50 InDirection:kGREYDirectionDown]
+  [[self ftr_scrollToCellAtIndex:20 byScrollingInAmounts:50 InDirection:kGREYDirectionDown]
       assertWithMatcher:grey_notNil()];
 }
 
 - (void)testSearchActionWithLargeScrollIncrements {
-  [[self scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
+  [[self ftr_scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
       assertWithMatcher:grey_notNil()];
-  [[self scrollToCellAtIndex:0 byScrollingInAmounts:200 InDirection:kGREYDirectionUp]
+  [[self ftr_scrollToCellAtIndex:0 byScrollingInAmounts:200 InDirection:kGREYDirectionUp]
       assertWithMatcher:grey_notNil()];
-  [[self scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
+  [[self ftr_scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
       assertWithMatcher:grey_notNil()];
 }
 
 - (void)testScrollToTop {
   // Scroll down.
-  [[self scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
+  [[self ftr_scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
       assertWithMatcher:grey_notNil()];
   // Scroll to top.
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"main_table_view")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   // And verify that we are at the top.
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"main_table_view")]
-      assertWithMatcher:[self matcherForScrolledToTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToTop]];
 }
 
 - (void)testScrollToTopWithPositiveInsets {
@@ -77,14 +77,14 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"insets toggle")]
       performAction:grey_turnSwitchOn(YES)];
   // Scroll down.
-  [[self scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
+  [[self ftr_scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
       assertWithMatcher:grey_notNil()];
   // Scroll to top.
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"main_table_view")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   // And verify that we are at the top.
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"main_table_view")]
-      assertWithMatcher:[self matcherForScrolledToTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToTop]];
 }
 
 - (void)testScrollToTopWithNegativeInsets {
@@ -94,14 +94,14 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"insets toggle")]
       performAction:grey_turnSwitchOn(YES)];
   // Scroll down.
-  [[self scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
+  [[self ftr_scrollToCellAtIndex:20 byScrollingInAmounts:200 InDirection:kGREYDirectionDown]
       assertWithMatcher:grey_notNil()];
   // Scroll to top.
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"main_table_view")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   // And verify that we are at the top.
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"main_table_view")]
-      assertWithMatcher:[self matcherForScrolledToTop]];
+      assertWithMatcher:[self ftr_matcherForScrolledToTop]];
 }
 
 - (void)testScrollToTopWhenAlreadyAtTheTopWithoutBounce {
@@ -122,7 +122,7 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"main_table_view")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   // Verify that top most cell is visible.
-  [[EarlGrey selectElementWithMatcher:[self matcherForCellAtIndex:0]]
+  [[EarlGrey selectElementWithMatcher:[self ftr_matcherForCellAtIndex:0]]
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
@@ -130,7 +130,7 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"main_table_view")]
       performAction:grey_scrollToContentEdge(kGREYContentEdgeTop)];
   // Verify that top most cell is visible.
-  [[EarlGrey selectElementWithMatcher:[self matcherForCellAtIndex:0]]
+  [[EarlGrey selectElementWithMatcher:[self ftr_matcherForCellAtIndex:0]]
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
@@ -196,21 +196,21 @@
 
 #pragma mark - Private
 
-- (id<GREYMatcher>)matcherForCellAtIndex:(NSInteger)index {
+- (id<GREYMatcher>)ftr_matcherForCellAtIndex:(NSInteger)index {
   return grey_accessibilityLabel([NSString stringWithFormat:@"Row %d", (int)index]);
 }
 
-- (GREYElementInteraction *)scrollToCellAtIndex:(NSInteger)index
-                         byScrollingInAmounts:(CGFloat)amount
-                                  InDirection:(GREYDirection)direction {
+- (GREYElementInteraction *)ftr_scrollToCellAtIndex:(NSInteger)index
+                               byScrollingInAmounts:(CGFloat)amount
+                                        InDirection:(GREYDirection)direction {
   id<GREYMatcher> matcher =
-      grey_allOf([self matcherForCellAtIndex:index], grey_interactable(), nil);
+      grey_allOf([self ftr_matcherForCellAtIndex:index], grey_interactable(), nil);
   return [[EarlGrey selectElementWithMatcher:matcher]
                 usingSearchAction:grey_scrollInDirection(direction, amount)
              onElementWithMatcher:grey_kindOfClass([UITableView class])];
 }
 
-- (GREYElementMatcherBlock *)matcherForScrolledToTop {
+- (GREYElementMatcherBlock *)ftr_matcherForScrolledToTop {
   BOOL (^isScrolledToTop)(id) = ^BOOL(id element) {
     CGPoint contentOffset = [(UIScrollView *)element contentOffset];
     UIEdgeInsets contentInset = [(UIScrollView *)element contentInset];
@@ -218,7 +218,7 @@
   };
   return [GREYElementMatcherBlock matcherWithMatchesBlock:isScrolledToTop
                                          descriptionBlock:^(id<GREYDescription> description) {
-    [description appendText:@"matcherForScrolledToTop"];
+    [description appendText:@"ftr_matcherForScrolledToTop"];
   }];
 }
 

--- a/Tests/FunctionalTests/Sources/FTRVisibilityTest.m
+++ b/Tests/FunctionalTests/Sources/FTRVisibilityTest.m
@@ -181,7 +181,7 @@
   NSError *error;
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"AView")]
       assertWithMatcher:grey_sufficientlyVisible() error:&error];
-  XCTAssertEqual(error.code, kGREYInteractionMultipleElementsMatchedErrorCode);
+  GREYAssertEqual(error.code, kGREYInteractionMultipleElementsMatchedErrorCode, @"should be equal");
 
   // Match against the first view present.
   [[EarlGrey selectElementWithMatcher:grey_allOf(grey_accessibilityLabel(@"AView"),
@@ -204,22 +204,22 @@
                                                  grey_accessibilityLabel(@"AView"),
                                                  nil)]
       assertWithMatcher:grey_sufficientlyVisible() error:&error];
-  XCTAssertEqual(error.code, kGREYInteractionElementNotFoundErrorCode);
+  GREYAssertEqual(error.code, kGREYInteractionElementNotFoundErrorCode, @"should be equal");
 
   // Use the element at index matcher with an incorrect matcher.
   [[EarlGrey selectElementWithMatcher:grey_allOf(grey_accessibilityLabel(@"InvalidView"),
                                                  grey_elementAtIndex(0), nil)]
       assertWithMatcher:grey_sufficientlyVisible() error:&error];
-  XCTAssertEqual(error.code, kGREYInteractionElementNotFoundErrorCode);
+  GREYAssertEqual(error.code, kGREYInteractionElementNotFoundErrorCode, @"should be equal");
 
   // Use the element at index matcher with an index greater than the number of
   // matched elements.
   [[EarlGrey selectElementWithMatcher:grey_allOf(grey_accessibilityLabel(@"AView"),
                                                  grey_elementAtIndex(99), nil)]
       assertWithMatcher:grey_sufficientlyVisible() error:&error];
-  XCTAssertEqual(error.code, kGREYInteractionElementNotFoundErrorCode);
+  GREYAssertEqual(error.code, kGREYInteractionElementNotFoundErrorCode, @"should be equal");
 
-  XCTAssertTrue(idSet.count == 3);
+  GREYAssertEqual(idSet.count, 3, @"should be equal");
 }
 
 @end

--- a/Tests/FunctionalTests/Sources/FTRVisibilityTest.m
+++ b/Tests/FunctionalTests/Sources/FTRVisibilityTest.m
@@ -163,19 +163,6 @@
       assertWithMatcher:grey_interactable()];
 }
 
-- (GREYAssertionBlock *)assertOnIDSet:(NSMutableSet *)idSet{
-  GREYAssertionBlock *assertAxId =
-      [GREYAssertionBlock assertionWithName:@"Check Accessibility Id"
-                    assertionBlockWithError:^BOOL(id element, NSError *__strong *errorOrNil) {
-                      NSParameterAssert(element);
-                      [grey_sufficientlyVisible() matches:element];
-                      UIView *view = element;
-                      [idSet addObject:view.accessibilityIdentifier];
-                      return YES;
-                    }];
-  return assertAxId;
-}
-
 - (void)testVisibilityOfViewsWithSameAccessibilityLabel {
   NSMutableSet *idSet = [NSMutableSet set];
   NSError *error;
@@ -186,17 +173,17 @@
   // Match against the first view present.
   [[EarlGrey selectElementWithMatcher:grey_allOf(grey_accessibilityLabel(@"AView"),
                                                  grey_elementAtIndex(0), nil)]
-      assert:[self assertOnIDSet:idSet]];
+      assert:[self ftr_assertOnIDSet:idSet]];
 
   // Match against the second view present.
   [[EarlGrey selectElementWithMatcher:grey_allOf(grey_accessibilityLabel(@"AView"),
                                                  grey_elementAtIndex(1), nil)]
-      assert:[self assertOnIDSet:idSet]];
+      assert:[self ftr_assertOnIDSet:idSet]];
 
   // Match against the third and last view present.
   [[EarlGrey selectElementWithMatcher:grey_allOf(grey_accessibilityLabel(@"AView"),
                                                  grey_elementAtIndex(2), nil)]
-      assert:[self assertOnIDSet:idSet]];
+      assert:[self ftr_assertOnIDSet:idSet]];
 
   // Try matching against the second view, but pass the defining matcher after the
   // |grey_elementAtIndex| matcher.
@@ -220,6 +207,21 @@
   GREYAssertEqual(error.code, kGREYInteractionElementNotFoundErrorCode, @"should be equal");
 
   GREYAssertEqual(idSet.count, 3, @"should be equal");
+}
+
+#pragma mark - Private
+
+- (GREYAssertionBlock *)ftr_assertOnIDSet:(NSMutableSet *)idSet {
+  GREYAssertionBlock *assertAxId =
+      [GREYAssertionBlock assertionWithName:@"Check Accessibility Id"
+                    assertionBlockWithError:^BOOL(id element, NSError *__strong *errorOrNil) {
+                      NSParameterAssert(element);
+                      [grey_sufficientlyVisible() matches:element];
+                      UIView *view = element;
+                      [idSet addObject:view.accessibilityIdentifier];
+                      return YES;
+                    }];
+  return assertAxId;
 }
 
 @end

--- a/Tests/FunctionalTests/Sources/FunctionalTestRig-Bridging-Header.h
+++ b/Tests/FunctionalTests/Sources/FunctionalTestRig-Bridging-Header.h
@@ -15,5 +15,3 @@
 //
 
 @import EarlGrey;
-
-#import "FTRMainViewController.h"


### PR DESCRIPTION
1) Only match SpringBoard alerts when not executing inside SpringBoard
2) Use GREYAsserts in FunctionalTestRig tests
3) In FunctionalTestRig tests, use ftr prefix for helper methods in test classes and move them to the bottom of the file
4) Dead code removal, style fix and URL fix