### PR TITLE
Refactor how failure description is generated in default failure handler and XCTestCase additions

### DIFF
--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.h
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.h
@@ -108,13 +108,11 @@ typedef NS_ENUM(NSUInteger, GREYXCTestCaseStatus) {
  *
  *  @param line        Line number at which the failure occured.
  *  @param file        Name of the file in which the failure occured.
- *  @param reason      Short reason for the failure.
  *  @param description Full description of the failure.
  */
 - (void)grey_markAsFailedAtLine:(NSUInteger)line
                          inFile:(NSString *)file
-                         reason:(NSString *)reason
-              detailDescription:(NSString *)description;
+                    description:(NSString *)description;
 
 /**
  *  @return A unique test outputs directory for the current test. All test related outputs should be

--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.m
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.m
@@ -156,12 +156,9 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
 
 - (void)grey_markAsFailedAtLine:(NSUInteger)line
                          inFile:(NSString *)file
-                         reason:(NSString *)reason
-              detailDescription:(NSString *)description {
-  NSString *fullException =
-      [NSString stringWithFormat:@"%@\n%@\n%@", reason, [NSThread callStackSymbols], description];
+                    description:(NSString *)description {
   gCurrentExecutingTestCase.continueAfterFailure = NO;
-  [gCurrentExecutingTestCase recordFailureWithDescription:fullException
+  [gCurrentExecutingTestCase recordFailureWithDescription:description
                                                    inFile:file
                                                    atLine:line
                                                  expected:NO];

--- a/EarlGrey/Exception/GREYDefaultFailureHandler.m
+++ b/EarlGrey/Exception/GREYDefaultFailureHandler.m
@@ -52,11 +52,12 @@ static NSUInteger gUnknownTestExceptionCounter = 0;
   }
 
   NSMutableString *log = [[NSMutableString alloc] init];
-  // Start on fresh new line.
-  [log appendString:@"\n"];
-  [log appendFormat:@"Exception: %@\n", exception.name];
   NSString *reason =
       exception.reason.length > 0 ? exception.reason : @"exception.reason was not provided";
+  [log appendFormat:@"%@\n\n", reason];
+  [log appendFormat:@"Bundle ID: %@\n\n", [[NSBundle mainBundle] bundleIdentifier]];
+  [log appendFormat:@"Stack trace: %@\n\n", [NSThread callStackSymbols]];
+  [log appendFormat:@"Exception: %@\n", exception.name];
   [log appendFormat:@"Reason: %@\n", reason];
   if (details.length > 0) {
     [log appendFormat:@"%@\n", details];
@@ -111,15 +112,10 @@ static NSUInteger gUnknownTestExceptionCounter = 0;
   }
 
   if (currentTestCase) {
-    [currentTestCase grey_markAsFailedAtLine:_lineNumber
-                                      inFile:_fileName
-                                      reason:exception.reason
-                           detailDescription:log];
+    [currentTestCase grey_markAsFailedAtLine:_lineNumber inFile:_fileName description:log];
   } else {
     // Happens when exception is thrown outside a valid test context (i.e. +setUp, +tearDown, etc.)
-    [[GREYFrameworkException exceptionWithName:exception.name
-                                        reason:log
-                                      userInfo:nil] raise];
+    [[GREYFrameworkException exceptionWithName:exception.name reason:log userInfo:nil] raise];
   }
 }
 


### PR DESCRIPTION
Refactoring, with minor changes in log output.

Improves how failure description is generated in default failure handler and XCTestCase additions.