### PR TITLE
Update Docs for EarlGreyContribs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,10 @@ The submitted code should adhere to the following:
   for formatting your comments and issues.
 * Refer to the [Google Objective-C style guide][objc_style] and
   [raywenderlich Swift style guide][swift_style] for our code conventions.
+* If a new custom API is being proposed to be added to EarlGrey, but is still in the
+  experimental phase, then please add it to the [EarlGreyContribs](https://github.com/google/EarlGrey/tree/master/Demo/EarlGreyContribs)
+  project for vetting out. Also, any example code that is added must first
+  be vetted in the EarlGreyContribs project.
 
 [objc_style]: https://google.github.io/styleguide/objcguide.xml
 [swift_style]: https://github.com/raywenderlich/swift-style-guide

--- a/Demo/EarlGreyContribs/README.md
+++ b/Demo/EarlGreyContribs/README.md
@@ -1,0 +1,15 @@
+# EarlGrey Contribs
+
+This sample project contains API's that are still in the experimental phase and need to be
+further polished or analyzed before adding as an official EarlGrey API.
+
+`EarlGreyContribs` is a simple project that contains two test targets -
+`EarlGreyContribsSwiftTests` and `EarlGreyContribsTests`, both of which are added to
+continuous integration.
+
+It is recommended that if you add an API to either one of the targets, you try and replicate
+it in the other as well.
+
+## Getting Started
+
+Similar to how the FunctionalTests project is set up, simply run the [setup script](https://github.com/google/EarlGrey/tree/master/Scripts/setup-earlgrey.sh). You can then open `EarlGreyContribs.xcodeproj` which is already pre-configured to run the tests.

--- a/Demo/EarlGreyExample/README.md
+++ b/Demo/EarlGreyExample/README.md
@@ -1,5 +1,4 @@
-EarlGrey Example
-=============================
+# EarlGrey Example
 
 An example that shows several features of EarlGrey.
 
@@ -8,8 +7,7 @@ An example that shows several features of EarlGrey.
 `EarlGreyExampleTests` and `EarlGreyExampleSwiftTests` are test targets that exercise
 different functionalities provide by EarlGrey, written in Objective-C and Swift.
 
-Getting Started
----------------
+## Getting Started
 
 Execute `gem install earlgrey` then `pod install` from the directory where you have downloaded
 the source of the example, then `open EarlGreyExample.xcworkspace` to open the example in xcode.


### PR DESCRIPTION
Issue: The EarlGreyContribs project has no setup guide or README.md.

What this does: Adds in a README for the EarlGreyContribs project along with a stipulation for its usage in CONTRIBUTING.md. Also fixes some minor grammatical changes.