### PR TITLE
Introducing retries if xcodebuild fails before tests are even run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,6 @@ rvm:
 env:
   matrix:
     - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="CONTRIB"
-    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL_SWIFT"
-    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="UNIT"
-    - DESTINATION="OS=9.2,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - DESTINATION="OS=9.1,name=iPad Pro" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - DESTINATION="OS=9.0,name=iPhone 6s Plus" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - DESTINATION="OS=8.4,name=iPad 2" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - DESTINATION="OS=8.4,name=iPad 2" SDK=iphonesimulator9.3 TYPE="UNIT"
-    - DESTINATION="OS=8.3,name=iPad Retina" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - DESTINATION="OS=8.2,name=iPad Air" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - DESTINATION="OS=8.1,name=iPhone 5" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - DESTINATION="OS=8.1,name=iPhone 4S" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
-    - TYPE="RUBY"
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,21 @@ rvm:
   - 2.2.2
 env:
   matrix:
+    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL_SWIFT"
+    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="CONTRIB"
+    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="CONTRIB_SWIFT"
+    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="UNIT"
+    - DESTINATION="OS=9.2,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=9.1,name=iPad Pro" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=9.0,name=iPhone 6s Plus" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=8.4,name=iPad 2" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=8.4,name=iPad 2" SDK=iphonesimulator9.3 TYPE="UNIT"
     - DESTINATION="OS=8.3,name=iPad Retina" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=8.2,name=iPad Air" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=8.1,name=iPhone 5" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=8.1,name=iPhone 4S" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - TYPE="RUBY"
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,6 @@ before_script:
   - Scripts/setup-earlgrey.sh
 script:
  - Scripts/travis.sh
+after_failure:
+ - tail -n 100 xcodebuild.log
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ before_script:
 script:
  - Scripts/travis.sh
 after_failure:
- - tail -n 100 xcodebuild.log
+ - cat xcodebuild.log
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ rvm:
   - 2.2.2
 env:
   matrix:
-    - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
+    - DESTINATION="OS=8.3,name=iPad Retina" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 before_script:

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -35,8 +35,13 @@ execute_xcodebuild() {
   fi
 
   for retry_attempts in {1..3}; do
+    # To retry on failure, disable exiting if command below fails.
+    set +e
     env NSUnbufferedIO=YES xcodebuild -project ${1} -scheme ${2} -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
-    if [ $? -ne 65 ]; then
+    retval=$?
+    # Re-enable exiting for command failures.
+    set -e
+  if [ ${retval} -ne 65 ]; then
       break
     fi
   done

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -43,7 +43,7 @@ execute_xcodebuild() {
     set -e
     # Even failed tests exit with code 65. Add a check to query xcodebuild.log that tests haven't
     # started.
-    if [[ ${retval} -ne 65 ]] && [[ $(grep -q "Test Suite" xcodebuild.log) ]]; then
+    if [[ ${retval} -ne 65 ]] || [[ $(grep -q "Test Suite" xcodebuild.log) ]]; then
       break
     fi
   done

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -41,7 +41,7 @@ execute_xcodebuild() {
     retval=$?
     # Re-enable exiting for command failures.
     set -e
-  if [ ${retval} -ne 65 ]; then
+    if [ ${retval} -ne 65 ]; then
       break
     fi
   done

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -19,7 +19,7 @@ set -euxo pipefail
 xcodebuild -version
 xcodebuild -showsdks
 
-# Runs xcodebuild retrying up to 3 times on failure with exit code 65.
+# Runs xcodebuild retrying up to 3 times on failure to start testing (exit code 65).
 # The following arguments specified in the order below:
 #  $1 : .xcodeproj file
 #  $2 : scheme to run
@@ -41,7 +41,9 @@ execute_xcodebuild() {
     retval=$?
     # Re-enable exiting for command failures.
     set -e
-    if [ ${retval} -ne 65 ]; then
+    # Even failed tests exit with code 65. Add a check to query xcodebuild.log that tests haven't
+    # started.
+    if [ ${retval} -ne 65 ] || [ grep -q "Test Suite" xcodebuild.log ]; then
       break
     fi
   done

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -40,8 +40,9 @@ execute_xcodebuild() {
     set +e
     env NSUnbufferedIO=YES xcodebuild -project ${1} -scheme ${2} -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
     retval_xcodebuild=$?
-    # Even failed tests exit with code 65. Add a check to ensure test haven't started.
-    # we achieve that by looking for keyword "Test Suite" in xcodebuild.log.
+    # Even failed tests exit with code 65, check to ensure tests haven't started.
+    # We achieve that by looking for keyword "Test Suite" in xcodebuild.log.
+    # TODO: this behavior may change.
     $(grep -q "Test Suite" xcodebuild.log)
     retval_grep=$?
     # Re-enable exiting for command failures.

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -19,21 +19,44 @@ set -euxo pipefail
 xcodebuild -version
 xcodebuild -showsdks
 
+# Runs xcodebuild retrying up to 3 times on failure with exit code 65.
+# The following arguments specified in the order below:
+#  $1 : .xcodeproj file
+#  $2 : scheme to run
+#
+# The output is prettified using xcpretty and redirected to xcodebuild.log for failure analysis.
+execute_xcodebuild() {
+  if [ -z ${1+x} ]; then
+    echo "first argument must be a valid .xcodeproj file"
+    exit 1
+  elif [ -z ${2+x} ]; then
+    echo "second argument must be a valid scheme"
+    exit 1
+  fi
+
+  for retry_attempts in {1..3}; do
+    env NSUnbufferedIO=YES xcodebuild -project ${1} -scheme ${2} -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
+    if [ $? -ne 65 ]; then
+      break
+    fi
+  done
+}
+
 if [ "${TYPE}" == "RUBY" ]; then
   rvm use 2.2.2;
   cd gem;
   bundle install --retry=3;
   rake;
 elif [ "${TYPE}" == "UNIT" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Tests/UnitTests/UnitTests.xcodeproj -scheme EarlGreyUnitTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
+  execute_xcodebuild Tests/UnitTests/UnitTests.xcodeproj EarlGreyUnitTests
 elif [ "${TYPE}" == "FUNCTIONAL_SWIFT" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalSwiftTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
+  execute_xcodebuild Tests/FunctionalTests/FunctionalTests.xcodeproj EarlGreyFunctionalSwiftTests
 elif [ "${TYPE}" == "FUNCTIONAL" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
+  execute_xcodebuild Tests/FunctionalTests/FunctionalTests.xcodeproj EarlGreyFunctionalTests
 elif [ "${TYPE}" == "CONTRIB" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj -scheme EarlGreyContribsTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
+  execute_xcodebuild Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj EarlGreyContribsTests
 elif [ "${TYPE}" == "CONTRIB_SWIFT" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj -scheme EarlGreyContribsSwiftTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
+  execute_xcodebuild Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj EarlGreyContribsSwiftTests
 else
   echo "Unrecognized Type: ${TYPE}"
   exit 1

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -43,7 +43,7 @@ execute_xcodebuild() {
     set -e
     # Even failed tests exit with code 65. Add a check to query xcodebuild.log that tests haven't
     # started.
-    if [ ${retval} -ne 65 ] || [ grep -q "Test Suite" xcodebuild.log ]; then
+    if [[ ${retval} -ne 65 ]] && [[ $(grep -q "Test Suite" xcodebuild.log) ]]; then
       break
     fi
   done

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -34,6 +34,7 @@ execute_xcodebuild() {
     exit 1
   fi
 
+  retval_xcodebuild=0
   for retry_attempts in {1..3}; do
     # To retry on failure, disable exiting if command below fails.
     set +e
@@ -49,6 +50,10 @@ execute_xcodebuild() {
       break
     fi
   done
+
+  if [[ ${retval_xcodebuild} -ne 0 ]]; then
+    exit ${retval_xcodebuild}
+  fi
 }
 
 if [ "${TYPE}" == "RUBY" ]; then

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -32,6 +32,7 @@ elif [ "${TYPE}" == "FUNCTIONAL" ]; then
   env NSUnbufferedIO=YES xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
 elif [ "${TYPE}" == "CONTRIB" ]; then
   env NSUnbufferedIO=YES xcodebuild -project Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj -scheme EarlGreyContribsTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
+elif [ "${TYPE}" == "CONTRIB_SWIFT" ]; then
   env NSUnbufferedIO=YES xcodebuild -project Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj -scheme EarlGreyContribsSwiftTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
 else
   echo "Unrecognized Type: ${TYPE}"

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -19,22 +19,21 @@ set -euxo pipefail
 xcodebuild -version
 xcodebuild -showsdks
 
-if [ "${TYPE}" == "UNIT" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Tests/UnitTests/UnitTests.xcodeproj -scheme EarlGreyUnitTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
-elif [ "${TYPE}" == "RUBY" ]; then
+if [ "${TYPE}" == "RUBY" ]; then
   rvm use 2.2.2;
   cd gem;
   bundle install --retry=3;
   rake;
+elif [ "${TYPE}" == "UNIT" ]; then
+  env NSUnbufferedIO=YES xcodebuild -project Tests/UnitTests/UnitTests.xcodeproj -scheme EarlGreyUnitTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
 elif [ "${TYPE}" == "FUNCTIONAL_SWIFT" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalSwiftTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
+  env NSUnbufferedIO=YES xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalSwiftTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
 elif [ "${TYPE}" == "FUNCTIONAL" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
+  env NSUnbufferedIO=YES xcodebuild -project Tests/FunctionalTests/FunctionalTests.xcodeproj -scheme EarlGreyFunctionalTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
 elif [ "${TYPE}" == "CONTRIB" ]; then
-  env NSUnbufferedIO=YES xcodebuild -project Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj -scheme EarlGreyContribsTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
-  env NSUnbufferedIO=YES xcodebuild -project Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj -scheme EarlGreyContribsSwiftTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c;
+  env NSUnbufferedIO=YES xcodebuild -project Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj -scheme EarlGreyContribsTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
+  env NSUnbufferedIO=YES xcodebuild -project Demo/EarlGreyContribs/EarlGreyContribs.xcodeproj -scheme EarlGreyContribsSwiftTests -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test | tee xcodebuild.log | xcpretty -s;
 else
   echo "Unrecognized Type: ${TYPE}"
   exit 1
 fi
-


### PR DESCRIPTION
If xcodebuild exits with code 65 and tests haven't been started it, retry up to 3 times in total. There is a possibility that due to compilation issue, error code 65 is returned, in which case all retries will fail with the same error code but it should be fairly inexpensive to do that.

Also redirecting all output to xcodebuild.log which will be printed on failure. We may want to upload the logs to some dashboard after failure but that's scoped for future.