### PR TITLE
Internal to external sync - 08/03/2016

### DIFF
--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.m
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.m
@@ -305,6 +305,7 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
 /**
  *  Creates a new directory under the specified @c path. If a directory already exists under the
  *  same path, it will be removed and a new, empty dir with the same name will be created.
+ *  Intermediate directories are created automatically.
  *
  *  @param      path     The path where a new directory is to be created.
  *  @param[out] outError A reference to receive errors that may have occured during the execution of

--- a/EarlGrey/Assertion/GREYAssertionDefines.h
+++ b/EarlGrey/Assertion/GREYAssertionDefines.h
@@ -201,7 +201,7 @@ GREY_EXTERN id<GREYFailureHandler> greyFailureHandler;
     I_GREYFormattedString(details__, __details, ##__VA_ARGS__); \
     [greyFailureHandler handleException:[GREYFrameworkException exceptionWithName:__exceptionName \
                                                                            reason:__description] \
-                              details:details__]; \
+                                details:details__]; \
   } while (NO)
 
 // No private macro should call this.

--- a/EarlGrey/Core/GREYAutomationSetup.m
+++ b/EarlGrey/Core/GREYAutomationSetup.m
@@ -23,6 +23,45 @@
 #import "Common/GREYDefines.h"
 #import "Common/GREYExposed.h"
 
+// Exception handler that was previously installed before we replaced it with our own.
+static NSUncaughtExceptionHandler *gPreviousUncaughtExceptionHandler;
+
+// Normal signal handler.
+typedef void (*SignalHandler)(int signum);
+
+// When SA_SIGINFO is set, it is an extended signal handler.
+typedef void (*SignalHandlerEX)(int signum, struct __siginfo *siginfo, void *context);
+
+// All signals that we want to handle.
+static const int gSignals[] = {
+  SIGQUIT,
+  SIGILL,
+  SIGTRAP,
+  SIGABRT,
+  SIGFPE,
+  SIGBUS,
+  SIGSEGV,
+  SIGSYS,
+};
+
+// Total number of signals we handle.
+static const int kNumSignals = sizeof(gSignals) / sizeof(gSignals[0]);
+
+// A union of normal and extended signal handler.
+typedef union GREYSignalHandlerUnion {
+  SignalHandler signalHandler;
+  SignalHandlerEX signalHandlerExtended;
+} GREYSignalHandlerUnion;
+
+// Saved signal handler with a bit indicating extended or normal handler signature.
+typedef struct GREYSignalHandler {
+  GREYSignalHandlerUnion handler;
+  bool extended;
+} GREYSignalHandler;
+
+// All previous signal handlers we replaced with our own.
+static GREYSignalHandler gPreviousSignalHandlers[kNumSignals];
+
 @implementation GREYAutomationSetup
 
 + (instancetype)sharedInstance {
@@ -105,57 +144,118 @@
 
 #pragma mark - Crash Handlers
 
+// Installs the default handler and raises the specified @c signum.
+static void grey_installDefaultHandlerAndRaise(int signum) {
+  // Install default and re-raise the signal.
+  struct sigaction defaultSignalAction;
+  memset(&defaultSignalAction, 0, sizeof(defaultSignalAction));
+  int result = sigemptyset(&defaultSignalAction.sa_mask);
+  if (result != 0) {
+    char *sigEmptyError = "Unable to empty sa_mask";
+    write(STDERR_FILENO, sigEmptyError, strlen(sigEmptyError));
+    kill(getpid(), SIGKILL);
+  }
+
+  defaultSignalAction.sa_handler = SIG_DFL;
+  if (sigaction(signum, &defaultSignalAction, NULL) == 0) {
+    // re-raise with default in place.
+    raise(signum);
+  }
+}
+
 // Call only asynchronous-safe functions within signal handlers
 // Learn more: https://www.securecoding.cert.org/confluence/display/c/SIG00-C.+Mask+signals+handled+by+noninterruptible+signal+handlers
-static void grey_signalHandler(int signal) {
-  char *signalString = strsignal(signal);
+static void grey_signalHandler(int signum) {
+  char *signalCaught = "Signal caught: ";
+  char *signalString = strsignal(signum);
+  write(STDERR_FILENO, signalCaught, strlen(signalCaught));
   write(STDERR_FILENO, signalString, strlen(signalString));
+
   write(STDERR_FILENO, "\n", 1);
   static const int kMaxStackSize = 128;
   void *callStack[kMaxStackSize];
   const int numFrames = backtrace(callStack, kMaxStackSize);
   backtrace_symbols_fd(callStack, numFrames, STDERR_FILENO);
-  kill(getpid(), SIGKILL);
+
+  int signalIndex = -1;
+  for (size_t i = 0; i < kNumSignals; i++) {
+    if (signum == gSignals[i]) {
+      signalIndex = (int)i;
+    }
+  }
+
+  if (signalIndex == -1) {  // Not found.
+    char *signalNotFound = "Caught signal not in handled signal array: ";
+    write(STDERR_FILENO, signalNotFound, strlen(signalNotFound));
+    write(STDERR_FILENO, signalString, strlen(signalString));
+    kill(getpid(), SIGKILL);
+  }
+
+  GREYSignalHandler previousSignalHandler = gPreviousSignalHandlers[signalIndex];
+  if (previousSignalHandler.extended) {
+    // We don't handle these yet, simply re-raise with default handler.
+    grey_installDefaultHandlerAndRaise(signum);
+  } else {
+    SignalHandler signalHandler = previousSignalHandler.handler.signalHandler;
+    if (signalHandler == SIG_DFL) {
+      grey_installDefaultHandlerAndRaise(signum);
+    } else if (signalHandler == SIG_IGN) {
+      // Ignore.
+    } else {
+      signalHandler(signum);
+    }
+  }
 }
 
 static void grey_uncaughtExceptionHandler(NSException *exception) {
   NSLog(@"Uncaught exception: %@", exception);
-  exit(-1);
-}
-
-static void grey_installSignalHandler(int signalId, struct sigaction *handler) {
-  int returnValue = sigaction(signalId, handler, NULL);
-  if (returnValue != 0) {
-    NSLog(@"Error installing %s handler: '%s'.", strsignal(signalId), strerror(errno));
+  if (gPreviousUncaughtExceptionHandler) {
+    gPreviousUncaughtExceptionHandler(exception);
+  } else {
+    exit(EXIT_FAILURE);
   }
 }
 
 + (void)grey_setupCrashHandlers {
   NSLog(@"Crash handler setup started.");
 
-  struct sigaction signalActionHandler;
-  memset(&signalActionHandler, 0, sizeof(signalActionHandler));
-  int result = sigemptyset(&signalActionHandler.sa_mask);
+  struct sigaction signalAction;
+  memset(&signalAction, 0, sizeof(signalAction));
+  int result = sigemptyset(&signalAction.sa_mask);
   if (result != 0) {
     NSLog(@"Unable to empty sa_mask. Return value:%d", result);
-    exit(-1);
+    exit(EXIT_FAILURE);
   }
-  signalActionHandler.sa_handler = &grey_signalHandler;
+  signalAction.sa_handler = &grey_signalHandler;
 
-  // Register the signal handlers.
-  grey_installSignalHandler(SIGQUIT, &signalActionHandler);
-  grey_installSignalHandler(SIGILL, &signalActionHandler);
-  grey_installSignalHandler(SIGTRAP, &signalActionHandler);
-  grey_installSignalHandler(SIGABRT, &signalActionHandler);
-  grey_installSignalHandler(SIGFPE, &signalActionHandler);
-  grey_installSignalHandler(SIGBUS, &signalActionHandler);
-  grey_installSignalHandler(SIGSEGV, &signalActionHandler);
-  grey_installSignalHandler(SIGSYS, &signalActionHandler);
+  for (size_t i = 0; i < kNumSignals; i++) {
+    int signum = gSignals[i];
+    struct sigaction previousSigAction;
+    memset(&previousSigAction, 0, sizeof(previousSigAction));
+
+    GREYSignalHandler *previousSignalHandler = &gPreviousSignalHandlers[i];
+    memset(previousSignalHandler, 0, sizeof(gPreviousSignalHandlers[0]));
+
+    int returnValue = sigaction(signum, &signalAction, &previousSigAction);
+    if (returnValue != 0) {
+      NSLog(@"Error installing %s handler. errorno:'%s'.", strsignal(signum), strerror(errno));
+      previousSignalHandler->extended = false;
+      previousSignalHandler->handler.signalHandler = SIG_IGN;
+    } else if (previousSigAction.sa_flags & SA_SIGINFO) {
+      previousSignalHandler->extended = true;
+      previousSignalHandler->handler.signalHandlerExtended =
+          previousSigAction.__sigaction_u.__sa_sigaction;
+    } else {
+      previousSignalHandler->extended = false;
+      previousSignalHandler->handler.signalHandler = previousSigAction.__sigaction_u.__sa_handler;
+    }
+  }
 
   // Register the handler for uncaught exceptions.
+  gPreviousUncaughtExceptionHandler = NSGetUncaughtExceptionHandler();
   NSSetUncaughtExceptionHandler(&grey_uncaughtExceptionHandler);
 
-  NSLog(@"Crash handlers setup complete.");
+  NSLog(@"Crash handlers setup completed.");
 }
 
 @end

--- a/Tests/FunctionalTests/Sources/FTRErrorAPITest.m
+++ b/Tests/FunctionalTests/Sources/FTRErrorAPITest.m
@@ -31,7 +31,7 @@
     assert(NULL);
   } @catch (id expectedException) {
     if (![expectedException isKindOfClass:[GREYFrameworkException class]]) {
-      NSAssert(NO, @"Incorrect exception class: %@ raised.", [expectedException class]);
+      NSLog(@"Incorrect exception class: %@ raised.", [expectedException class]);
       @throw;
     }
   }

--- a/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.h
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.h
@@ -20,6 +20,11 @@
 @interface FTRNetworkProxy : NSURLProtocol
 
 /**
+ *  @return @c YES if proxy is enabled, @c NO otherwise.
+ */
++ (BOOL)ftr_isProxyEnabled;
+
+/**
  *  Enables (if @c enabled is @c YES) or disables the proxy.
  *
  *  @param enabled A BOOL specifing whether to enable or disable the proxy.

--- a/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.m
@@ -57,6 +57,12 @@ static NSString *const kFTRNetworkProxyErrorDomain =
   }
 }
 
++ (BOOL)ftr_isProxyEnabled {
+  @synchronized(self) {
+    return gFTRProxyEnabled;
+  }
+}
+
 + (void)ftr_addProxyRuleForUrlsMatchingRegexString:(NSString *)regexString
                                     responseString:(NSString *)data {
   @synchronized(self) {


### PR DESCRIPTION
What this does:

* Adds an analytics Proxy change to not rely on the order of tests.
* Enables chaining of exception and signal handlers. You can now reraise the same signal with default handlers in places where before, you'd see a stack dump.