### PR TITLE
Disabled UIPicker test

### DIFF
--- a/EarlGrey/Action/GREYPickerAction.m
+++ b/EarlGrey/Action/GREYPickerAction.m
@@ -40,6 +40,7 @@
   NSString *name =
       [NSString stringWithFormat:@"Set picker column %ld to value \"%@\"", (long)column, value];
   self = [super initWithName:name constraints:grey_allOf(grey_interactable(),
+                                                         grey_userInteractionEnabled(),
                                                          grey_not(grey_systemAlertViewShown()),
                                                          grey_kindOfClass([UIPickerView class]),
                                                          nil)];

--- a/Tests/FunctionalTests/Sources/FTRPickerViewInteractionTest.m
+++ b/Tests/FunctionalTests/Sources/FTRPickerViewInteractionTest.m
@@ -26,6 +26,21 @@
   [self openTestViewNamed:@"Picker Views"];
 }
 
+- (void)testInteractionIsImpossibleIfInteractionDisabled {
+    [[EarlGrey selectElementWithMatcher:grey_text(@"Disabled")] performAction:grey_tap()];
+    
+    NSError *error;
+    
+    [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"DisabledPickerId")]
+     performAction:[GREYActions actionForSetPickerColumn:0 toValue:@"Green"]
+     error:&error];
+    
+    GREYAssertTrue(error.code == kGREYInteractionActionFailedErrorCode, @"code should match");
+    
+    [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"DisabledPickerId")]
+     assertWithMatcher:grey_pickerColumnSetToValue(0, @"Red")];
+}
+
 - (void)testDateOnlyPicker {
   NSString *dateString = @"1986/12/26";
   NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];

--- a/Tests/FunctionalTests/TestRig/Sources/FTRPickerViewController.h
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRPickerViewController.h
@@ -18,6 +18,7 @@
 
 @property(nonatomic, retain) IBOutlet UIPickerView *customPicker;
 @property(nonatomic, retain) IBOutlet UIDatePicker *datePicker;
+@property (weak, nonatomic) IBOutlet UIPickerView *disabledPicker;
 @property(nonatomic, retain) IBOutlet UISegmentedControl *datePickerSegmentedControl;
 @property(nonatomic, retain) IBOutlet UIButton *clearLabelButton;
 @property(weak, nonatomic) IBOutlet UILabel *dateLabel;

--- a/Tests/FunctionalTests/TestRig/Sources/FTRPickerViewController.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRPickerViewController.m
@@ -20,6 +20,7 @@
 
 @synthesize customPicker;
 @synthesize datePicker;
+@synthesize disabledPicker;
 @synthesize datePickerSegmentedControl;
 @synthesize customColumn1Array;
 @synthesize customColumn2Array;
@@ -45,9 +46,11 @@
 
   [self.customPicker setHidden:YES];
   [self.datePicker setHidden:YES];
+    [self.disabledPicker setHidden:YES];
 
   self.datePicker.accessibilityIdentifier = @"DatePickerId";
   self.customPicker.accessibilityIdentifier = @"CustomPickerId";
+  self.disabledPicker.accessibilityIdentifier = @"DisabledPickerId";
   self.dateLabel.accessibilityIdentifier = @"DateLabelId";
   self.clearLabelButton.accessibilityIdentifier = @"ClearDateLabelButtonId";
 
@@ -69,6 +72,7 @@
 - (IBAction)valueChanged:(id)sender {
   [datePicker setHidden:YES];
   [customPicker setHidden:YES];
+  [disabledPicker setHidden:YES];
   NSInteger selectedSegment = datePickerSegmentedControl.selectedSegmentIndex;
 
   switch (selectedSegment) {
@@ -91,6 +95,8 @@
     case 4:
       [customPicker setHidden:NO];
       break;
+    case 5:
+      [disabledPicker setHidden:NO];
   }
 }
 

--- a/Tests/FunctionalTests/TestRig/Sources/FTRPickerViewController.xib
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRPickerViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="13F1077" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FTRPickerViewController">
@@ -12,6 +12,7 @@
                 <outlet property="dateLabel" destination="XMm-0B-uOK" id="z5c-bW-3XC"/>
                 <outlet property="datePicker" destination="nsh-tZ-mIw" id="ZAa-Ka-SLh"/>
                 <outlet property="datePickerSegmentedControl" destination="SKZ-9B-Fzx" id="JO0-1t-WVj"/>
+                <outlet property="disabledPicker" destination="337-zK-QgX" id="jU6-uC-Ugd"/>
                 <outlet property="view" destination="1" id="NcN-en-NCW"/>
             </connections>
         </placeholder>
@@ -34,6 +35,7 @@
                         <segment title="DateTime"/>
                         <segment title="Counter"/>
                         <segment title="Custom"/>
+                        <segment title="Disabled"/>
                     </segments>
                     <connections>
                         <action selector="valueChanged:" destination="-1" eventType="valueChanged" id="nWS-n6-KYk"/>
@@ -60,13 +62,15 @@
                         <action selector="clearDateLabelButtonTapped:" destination="-1" eventType="touchUpInside" id="mvT-Ug-LOM"/>
                     </connections>
                 </button>
+                <pickerView userInteractionEnabled="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="337-zK-QgX">
+                    <rect key="frame" x="0.0" y="129" width="320" height="162"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="XRm-Up-6D1"/>
+                        <outlet property="delegate" destination="-1" id="LO7-do-cDW"/>
+                    </connections>
+                </pickerView>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
         </view>
     </objects>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>


### PR DESCRIPTION
I have implemented @khandpur's advice as far as I could. 

1) I have added a Disabled UIPicker in the Interface builder on top of the others. It is intergrated within the same functions and uses the same DataSource and Delegate as the custom Picker (File Owner). 
Only within the Interface builder I have disabled the UIPicker. I could also do this only in code or do both. Please let me know what is required. 

2) I have added a test, to see if the UIPicker throws an error if disabled. I do not know if I am correctly checking if the Error is populated correctly. If you have a example test I am very willing to integrate it. 

3) I have added a constrain to the UIPickerAction as requested. 

Feel free to give me any advice or critic, this is my first pull request and I would like to learn. 

note: I have 3 failing tests at the Functional test, the WebViewTests. I did not change them so that is strange. All UnitTests ran successfully. 

note: the GREYPinchAction.m line 163 and 164 gave a build error, so I had to cast them to CGFloat. This is not part of my fix.

