### PR TITLE
Fix Ruby 2.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ language: objective-c
 osx_image: xcode7.3
 sudo: false
 rvm:
-  - 2.2.2
+  - 2.2.5
 env:
   matrix:
     - DESTINATION="OS=9.3,name=iPhone 6s" SDK=iphonesimulator9.3 TYPE="FUNCTIONAL"


### PR DESCRIPTION
`osx_image: xcode7.3` means we're using [the `OS X 10.11` image](https://docs.travis-ci.com/user/osx-ci-environment/) which removed support for 2.2.2. Ruby 2.2.5 [is supported on 10.11.](http://rubies.travis-ci.org/)