### PR TITLE
make style more Swifty

### DIFF
--- a/gem/lib/earlgrey/files/Swift-2.2/EarlGrey.swift
+++ b/gem/lib/earlgrey/files/Swift-2.2/EarlGrey.swift
@@ -17,15 +17,15 @@
 import EarlGrey
 
 public func grey_allOfMatchers(args: AnyObject...) -> GREYMatcher! {
-  return GREYAllOf.init(matchers: args)
+  return GREYAllOf(matchers: args)
 }
 
 public func grey_anyOfMatchers(args: AnyObject...) -> GREYMatcher! {
-  return GREYAnyOf.init(matchers: args)
+  return GREYAnyOf(matchers: args)
 }
 
-public func EarlGrey() -> EarlGreyImpl! {
-  return EarlGreyImpl.invokedFromFile(__FILE__, lineNumber: __LINE__)
+public func EarlGrey(file: String = __FILE__, line: UInt = __LINE__) -> EarlGreyImpl! {
+  return EarlGreyImpl.invokedFromFile(file, lineNumber: line)
 }
 
 public func GREYAssert(@autoclosure expression: () -> BooleanType, reason: String) {
@@ -104,10 +104,10 @@ private func GREYAssert(@autoclosure expression: () -> BooleanType,
     }
 }
 
-private func GREYSetCurrentAsFailable() {
+private func GREYSetCurrentAsFailable(file: String = __FILE__, line: UInt = __LINE__) {
   let greyFailureHandlerSelector =
   Selector("GREYFailureHandler.setInvocationFile(__FILE__, andInvocationLine:__LINE__)")
   if greyFailureHandler.respondsToSelector(greyFailureHandlerSelector) {
-    greyFailureHandler.setInvocationFile!(__FILE__, andInvocationLine: __LINE__)
+    greyFailureHandler.setInvocationFile!(file, andInvocationLine: line)
   }
 }

--- a/gem/lib/earlgrey/files/Swift-3.0/EarlGrey.swift
+++ b/gem/lib/earlgrey/files/Swift-3.0/EarlGrey.swift
@@ -15,15 +15,15 @@
 //
 
 public func grey_allOfMatchers(args: AnyObject...) -> GREYMatcher! {
-  return GREYAllOf.init(matchers: args)
+  return GREYAllOf(matchers: args)
 }
 
 public func grey_anyOfMatchers(args: AnyObject...) -> GREYMatcher! {
-  return GREYAnyOf.init(matchers: args)
+  return GREYAnyOf(matchers: args)
 }
 
-public func EarlGrey() -> EarlGreyImpl! {
-  return EarlGreyImpl.invokedFromFile(#file, lineNumber: #line)
+public func EarlGrey(file: String = #file, line: UInt = #line) -> EarlGreyImpl! {
+  return EarlGreyImpl.invokedFromFile(file, lineNumber: line)
 }
 
 public func GREYAssert(@autoclosure expression: () -> BooleanType, reason: String) {
@@ -102,10 +102,10 @@ private func GREYAssert(@autoclosure expression: () -> BooleanType,
   }
 }
 
-private func GREYSetCurrentAsFailable() {
+private func GREYSetCurrentAsFailable(file: String = #file, line: UInt = #line) {
   let greyFailureHandlerSelector =
       #selector(GREYFailureHandler.setInvocationFile(_:andInvocationLine:))
   if greyFailureHandler.respondsToSelector(greyFailureHandlerSelector) {
-    greyFailureHandler.setInvocationFile!(#file, andInvocationLine: #line)
+    greyFailureHandler.setInvocationFile!(file, andInvocationLine: line)
   }
 }


### PR DESCRIPTION
I think that:

- `.init` doesn't need in this case
- usage of `#file` and `#line` is suitable in this PR
    - https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Expressions.html#//apple_ref/doc/uid/TP40014097-CH32-ID390
