### PR TITLE
Send change notifications in grey_replaceText

### DIFF
--- a/EarlGrey/Action/GREYActions.m
+++ b/EarlGrey/Action/GREYActions.m
@@ -310,7 +310,7 @@
 /**
  *  Set the UITextField text value directly, bypassing the iOS keyboard.
  *
- *  @param text     The text to be typed.
+ *  @param text The text to be typed.
  *
  *  @return @c YES if the action succeeded, else @c NO. If an action returns @c NO, it does not
  *          mean that the action was not performed at all but somewhere during the action execution
@@ -329,13 +329,18 @@
     if ([element grey_isWebAccessibilityElement]) {
       [GREYActions grey_webSetText:element text:text];
     } else {
+      BOOL elementIsUIControl = [element isKindOfClass:[UIControl class]];
       BOOL elementIsUITextField = [element isKindOfClass:[UITextField class]];
 
       // Did begin editing notifications.
-      [element sendActionsForControlEvents:UIControlEventEditingDidBegin];
+      if (elementIsUIControl) {
+        [element sendActionsForControlEvents:UIControlEventEditingDidBegin];
+      }
+
       if (elementIsUITextField) {
         NSNotification *notification =
-            [NSNotification notificationWithName:UITextFieldTextDidBeginEditingNotification object:element];
+            [NSNotification notificationWithName:UITextFieldTextDidBeginEditingNotification
+                                          object:element];
         [NSNotificationCenter.defaultCenter postNotification:notification];
       }
 
@@ -343,19 +348,25 @@
       [element setText:text];
 
       // Did change editing notifications.
-      [element sendActionsForControlEvents:UIControlEventEditingChanged];
+      if (elementIsUIControl) {
+        [element sendActionsForControlEvents:UIControlEventEditingChanged];
+      }
       if (elementIsUITextField) {
         NSNotification *notification =
-            [NSNotification notificationWithName:UITextFieldTextDidChangeNotification object:element];
+            [NSNotification notificationWithName:UITextFieldTextDidChangeNotification
+                                          object:element];
         [NSNotificationCenter.defaultCenter postNotification:notification];
       }
 
       // Did end editing notifications.
-      [element sendActionsForControlEvents:UIControlEventEditingDidEndOnExit];
-      [element sendActionsForControlEvents:UIControlEventEditingDidEnd];
+      if (elementIsUIControl) {
+        [element sendActionsForControlEvents:UIControlEventEditingDidEndOnExit];
+        [element sendActionsForControlEvents:UIControlEventEditingDidEnd];
+      }
       if (elementIsUITextField) {
         NSNotification *notification =
-            [NSNotification notificationWithName:UITextFieldTextDidEndEditingNotification object:element];
+            [NSNotification notificationWithName:UITextFieldTextDidEndEditingNotification
+                                          object:element];
         [NSNotificationCenter.defaultCenter postNotification:notification];
       }
     }

--- a/EarlGrey/Action/GREYActions.m
+++ b/EarlGrey/Action/GREYActions.m
@@ -330,6 +330,16 @@
       [GREYActions grey_webSetText:element text:text];
     } else {
       [element setText:text];
+            // For UIControl-s, send actions for UIControlEventEditingChanged, as it is not sent when directly
+      // setting the text.
+      [element sendActionsForControlEvents:UIControlEventEditingChanged];
+      // For UITextField-s, send the UITextFieldTextDidChangeNotification notification, as it is not sent
+      // when directly setting the text.
+      if ([element isKindOfClass:[UITextField class]]) {
+        NSNotification *notification =
+            [NSNotification notificationWithName:UITextFieldTextDidChangeNotification object:element];
+        [NSNotificationCenter.defaultCenter postNotification:notification];
+      }
     }
     return YES;
   }];

--- a/EarlGrey/Action/GREYActions.m
+++ b/EarlGrey/Action/GREYActions.m
@@ -329,11 +329,33 @@
     if ([element grey_isWebAccessibilityElement]) {
       [GREYActions grey_webSetText:element text:text];
     } else {
+      BOOL elementIsUITextField = [element isKindOfClass:[UITextField class]];
+
+      // Did begin editing notifications.
+      [element sendActionsForControlEvents:UIControlEventEditingDidBegin];
+      if (elementIsUITextField) {
+        NSNotification *notification =
+            [NSNotification notificationWithName:UITextFieldTextDidBeginEditingNotification object:element];
+        [NSNotificationCenter.defaultCenter postNotification:notification];
+      }
+
+      // Actually change the text.
       [element setText:text];
+
+      // Did change editing notifications.
       [element sendActionsForControlEvents:UIControlEventEditingChanged];
-      if ([element isKindOfClass:[UITextField class]]) {
+      if (elementIsUITextField) {
         NSNotification *notification =
             [NSNotification notificationWithName:UITextFieldTextDidChangeNotification object:element];
+        [NSNotificationCenter.defaultCenter postNotification:notification];
+      }
+
+      // Did end editing notifications.
+      [element sendActionsForControlEvents:UIControlEventEditingDidEndOnExit];
+      [element sendActionsForControlEvents:UIControlEventEditingDidEnd];
+      if (elementIsUITextField) {
+        NSNotification *notification =
+            [NSNotification notificationWithName:UITextFieldTextDidEndEditingNotification object:element];
         [NSNotificationCenter.defaultCenter postNotification:notification];
       }
     }

--- a/EarlGrey/Action/GREYActions.m
+++ b/EarlGrey/Action/GREYActions.m
@@ -330,11 +330,7 @@
       [GREYActions grey_webSetText:element text:text];
     } else {
       [element setText:text];
-            // For UIControl-s, send actions for UIControlEventEditingChanged, as it is not sent when directly
-      // setting the text.
       [element sendActionsForControlEvents:UIControlEventEditingChanged];
-      // For UITextField-s, send the UITextFieldTextDidChangeNotification notification, as it is not sent
-      // when directly setting the text.
       if ([element isKindOfClass:[UITextField class]]) {
         NSNotification *notification =
             [NSNotification notificationWithName:UITextFieldTextDidChangeNotification object:element];

--- a/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
+++ b/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
@@ -167,7 +167,6 @@ class FunctionalTestRigSwiftTests: XCTestCase {
       element.addTarget(self, action: #selector(self.editingChanged), forControlEvents: .EditingChanged)
       return true
     }
-
   }
 
   var textFieldChangedReceived = false


### PR DESCRIPTION
When setting the text property directly, neither UITextFieldTextDidChangeNotification nor UIControlEventEditingChanged are sent.
Since the goal of grey_replaceText is to simulate a user entry, the notifications should be sent manually.

Closes https://github.com/google/EarlGrey/issues/253.