### PR TITLE
Fix break in EarlGrey gem 0.0.12 caused by conflicting xcodeproj version.

### DIFF
--- a/gem/earlgrey.gemspec
+++ b/gem/earlgrey.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'colored',   '>= 1.2'
   # Temporary check while https://github.com/CocoaPods/Xcodeproj/issues/416 is fixed.
   # Revert to 'xcodeproj', '>= 1.0' afterwards.
-  s.add_runtime_dependency 'xcodeproj', '1.3.0'
+  s.add_runtime_dependency 'xcodeproj', '>= 1.3.0'
   s.add_runtime_dependency 'thor',      '>= 0.19.1'
 
   s.add_development_dependency 'rspec',       '>= 3.4.0'


### PR DESCRIPTION
This is going to break the ruby tests, which will be fixed separately.