### PR TITLE
Making it safe to invoke default failure handlers multiple times.

### DIFF
--- a/EarlGrey/Additions/NSURL+GREYAdditions.m
+++ b/EarlGrey/Additions/NSURL+GREYAdditions.m
@@ -15,6 +15,7 @@
 //
 
 #import "Additions/NSURL+GREYAdditions.h"
+#import "Common/GREYVerboseLogger.h"
 
 #import <objc/runtime.h>
 
@@ -46,7 +47,7 @@ static void const *const kFrameworkBlacklistedRegExKey = &kFrameworkBlacklistedR
                                options:0
                                  range:NSMakeRange(0, [stringURL length])];
     if (numMatches > 0) {
-      NSLog(@"Matched a blacklisted URL: %@", stringURL);
+      GREYLogVerbose(@"Matched a blacklisted URL: %@", stringURL);
       return NO;
     }
   }

--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.h
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.h
@@ -19,43 +19,43 @@
 
 /**
  *  Posted immediately prior to XCTestCase::setUp. The @c userInfo dictionary contains
- *  the current XCTestCase.
+ *  the executing XCTestCase.
  */
 UIKIT_EXTERN NSString *const kGREYXCTestCaseInstanceWillSetUp;
 
 /**
  *  Posted immediately after XCTestCase::setUp is called. The @c userInfo dictionary contains the
- *  current XCTestCase.
+ *  executing XCTestCase.
  */
 UIKIT_EXTERN NSString *const kGREYXCTestCaseInstanceDidSetUp;
 
 /**
  *  Posted immediately prior to XCTestCase::tearDown. The @c userInfo dictionary contains
- *  the current XCTestCase.
+ *  the executing XCTestCase.
  */
 UIKIT_EXTERN NSString *const kGREYXCTestCaseInstanceWillTearDown;
 
 /**
  *  Posted immediately after XCTestCase::tearDown is called. The @c userInfo dictionary contains
- *  the current XCTestCase.
+ *  the executing XCTestCase.
  */
 UIKIT_EXTERN NSString *const kGREYXCTestCaseInstanceDidTearDown;
 
 /**
  *  Posted immediately after XCTestCase::invokeTest is executed successfully, denoting that the
- *  test has passed. The @c userInfo dictionary contains the current XCTestCase.
+ *  test has passed. The @c userInfo dictionary contains the executing XCTestCase.
  */
 UIKIT_EXTERN NSString *const kGREYXCTestCaseInstanceDidPass;
 
 /**
  *  Posted immediately after XCTestCase::invokeTest raises an Exception, denoting that the test has
- *  failed. The @c userInfo dictionary contains the current XCTestCase.
+ *  failed. The @c userInfo dictionary contains the executing XCTestCase.
  */
 UIKIT_EXTERN NSString *const kGREYXCTestCaseInstanceDidFail;
 
 /**
  *  Posted immediately after a XCTestCase finishes, successfully or not. The @c userInfo dictionary
- *  contains the current XCTestCase.
+ *  contains the executing XCTestCase.
  */
 UIKIT_EXTERN NSString *const kGREYXCTestCaseInstanceDidFinish;
 
@@ -81,14 +81,14 @@ typedef NS_ENUM(NSUInteger, GREYXCTestCaseStatus) {
 @interface XCTestCase (GREYAdditions)
 
 /**
- *  @return The current XCTestCase being executed or @c nil if called outside context of a test
+ *  @return The current XCTestCase being executed or @c nil if called outside the context of a test
  *          method.
  */
 + (XCTestCase *)grey_currentTestCase;
 
 /**
- *  @return The name of the current test method being executed or @c nil if called outside context
- *          of a test method.
+ *  @return The name of the current test method being executed or @c nil if called outside the
+ *          context of a test method.
  */
 - (NSString *)grey_testMethodName;
 
@@ -98,7 +98,7 @@ typedef NS_ENUM(NSUInteger, GREYXCTestCaseStatus) {
 - (NSString *)grey_testClassName;
 
 /**
- *  @return The status of the currently running test.
+ *  @return The status (passed, failed, unknown) of this test.
  */
 - (GREYXCTestCaseStatus)grey_status;
 

--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.m
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.m
@@ -157,11 +157,8 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
 - (void)grey_markAsFailedAtLine:(NSUInteger)line
                          inFile:(NSString *)file
                     description:(NSString *)description {
-  gCurrentExecutingTestCase.continueAfterFailure = NO;
-  [gCurrentExecutingTestCase recordFailureWithDescription:description
-                                                   inFile:file
-                                                   atLine:line
-                                                 expected:NO];
+  self.continueAfterFailure = NO;
+  [self recordFailureWithDescription:description inFile:file atLine:line expected:NO];
   // If the test fails outside of the main thread in a nested runloop it will not be interrupted
   // until it's back in the outer most runloop. Raise an exception to interrupt the test immediately
   [[GREYFrameworkException exceptionWithName:kInternalTestInterruptException
@@ -240,7 +237,6 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
                                     expected:NO];
           break;
       }
-
       object_setClass(self.invocation, originalInvocationClass);
       [self grey_sendNotification:kGREYXCTestCaseInstanceDidFinish];
       // We only reset the current test case after all possible notifications have been sent.
@@ -293,44 +289,6 @@ NSString *const kGREYXCTestCaseNotificationKey = @"GREYXCTestCaseNotificationKey
  */
 - (void)grey_setStatus:(GREYXCTestCaseStatus)status {
   objc_setAssociatedObject(self, kTestCaseStatus, @(status), OBJC_ASSOCIATION_RETAIN);
-}
-
-/**
- *  Creates a new directory under the specified @c path. If a directory already exists under the
- *  same path, it will be removed and a new, empty dir with the same name will be created.
- *  Intermediate directories are created automatically.
- *
- *  @param      path     The path where a new directory is to be created.
- *  @param[out] outError A reference to receive errors that may have occured during the execution of
- *                       this method.
- *
- *  @return @c YES on success, @c NO otherwise.
- */
-- (BOOL)grey_createDirRemovingExistingDir:(NSString *)path error:(NSError **)outError {
-  NSParameterAssert(path);
-  NSParameterAssert(outError);
-
-  NSFileManager *manager = [NSFileManager defaultManager];
-  BOOL isDirectory;
-  if ([manager fileExistsAtPath:path isDirectory:&isDirectory]) {
-    if (!isDirectory) {
-      NSDictionary *errorUserInfo =
-          @{ NSLocalizedDescriptionKey: @"File not deleted as it not a directory." };
-      *outError = [NSError errorWithDomain:NSCocoaErrorDomain
-                                      code:NSFileReadInvalidFileNameError
-                                  userInfo:errorUserInfo];
-      return NO;
-    }
-
-    if (![manager removeItemAtPath:path error:outError]) {
-      return NO;
-    }
-  }
-
-  return [manager createDirectoryAtPath:path
-             withIntermediateDirectories:YES
-                              attributes:nil
-                                   error:outError];
 }
 
 @end

--- a/EarlGrey/Common/GREYVerboseLogger.h
+++ b/EarlGrey/Common/GREYVerboseLogger.h
@@ -29,7 +29,9 @@
  *    -kGREYAllowVerboseLogging YES
  *  @endcode
  *  Or from NSUserDefaults, by adding the @c kGREYAllowVerboseLogging key.
- *  [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kGREYAllowVerboseLogging];
+ *  @code
+ *    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kGREYAllowVerboseLogging];
+ *  @endcode
  *
  *  @remark Once you set this, as with any NSUserDefault, you need to explicitly turn it off
  *          or delete and re-install the app under test.

--- a/EarlGrey/Core/GREYAutomationSetup.m
+++ b/EarlGrey/Core/GREYAutomationSetup.m
@@ -251,12 +251,11 @@ static void grey_uncaughtExceptionHandler(NSException *exception) {
       previousSignalHandler->handler.signalHandler = previousSigAction.__sigaction_u.__sa_handler;
     }
   }
-
   // Register the handler for uncaught exceptions.
   gPreviousUncaughtExceptionHandler = NSGetUncaughtExceptionHandler();
   NSSetUncaughtExceptionHandler(&grey_uncaughtExceptionHandler);
 
-  NSLog(@"Crash handlers setup completed.");
+  NSLog(@"Crash handler setup completed.");
 }
 
 @end

--- a/EarlGrey/Exception/GREYDefaultFailureHandler.m
+++ b/EarlGrey/Exception/GREYDefaultFailureHandler.m
@@ -52,8 +52,10 @@ static NSUInteger gUnknownTestExceptionCounter = 0;
   }
 
   NSMutableString *log = [[NSMutableString alloc] init];
-  NSString *reason =
-      exception.reason.length > 0 ? exception.reason : @"exception.reason was not provided";
+  NSString *reason = exception.reason;
+  if (reason.length == 0) {
+    reason = @"exception.reason was not provided";
+  }
   [log appendFormat:@"%@\n\n", reason];
   [log appendFormat:@"Bundle ID: %@\n\n", [[NSBundle mainBundle] bundleIdentifier]];
   [log appendFormat:@"Stack trace: %@\n\n", [NSThread callStackSymbols]];
@@ -76,6 +78,10 @@ static NSUInteger gUnknownTestExceptionCounter = 0;
 
   // Save and log screenshot and before and after images (if available).
   NSString *screenshotDir = GREY_CONFIG_STRING(kGREYConfigKeyScreenshotDirLocation);
+  NSString *uniqueSubDirName =
+      [NSString stringWithFormat:@"%@-%@", exception.name, [[NSUUID UUID] UUIDString]];
+  screenshotDir = [screenshotDir stringByAppendingPathComponent:uniqueSubDirName];
+
   [self grey_savePNGImage:[GREYScreenshotUtil grey_takeScreenshotAfterScreenUpdates:NO]
               toFileNamed:[NSString stringWithFormat:@"%@.png", screenshotName]
               inDirectory:screenshotDir

--- a/EarlGrey/Exception/GREYFailureHandler.h
+++ b/EarlGrey/Exception/GREYFailureHandler.h
@@ -19,7 +19,7 @@
 @class GREYFrameworkException;
 
 /**
- *  Protocol for handling framework failures such as failure of an action.
+ *  Protocol for handling failures (such as failure of actions and assertions) raised by EarlGrey.
  */
 @protocol GREYFailureHandler<NSObject>
 


### PR DESCRIPTION
- It is safe to invoke failure handler multiple times without fearing loss of previous failure artifacts
- Adding some verbose logging and fixing minor typo [ci skip]