### PR TITLE
More Swifty style for Swift 2.2(#file, #line, #selector)

### DIFF
--- a/gem/lib/earlgrey/files/Swift-2.2/EarlGrey.swift
+++ b/gem/lib/earlgrey/files/Swift-2.2/EarlGrey.swift
@@ -24,7 +24,7 @@ public func grey_anyOfMatchers(args: AnyObject...) -> GREYMatcher! {
   return GREYAnyOf(matchers: args)
 }
 
-public func EarlGrey(file: String = __FILE__, line: UInt = __LINE__) -> EarlGreyImpl! {
+public func EarlGrey(file: String = #file, line: UInt = #line) -> EarlGreyImpl! {
   return EarlGreyImpl.invokedFromFile(file, lineNumber: line)
 }
 
@@ -78,7 +78,7 @@ public func GREYAssertNotEqualObjects<T : Equatable>(@autoclosure left: () -> T?
 public func GREYFail(reason: String) {
   greyFailureHandler.handleException(GREYFrameworkException(name: kGREYAssertionFailedException,
     reason: reason),
-                                     details: "")
+    details: "")
 }
 
 @available(*, deprecated=1.2.0, message="Please use GREYFAIL::withDetails instead.")
@@ -104,9 +104,9 @@ private func GREYAssert(@autoclosure expression: () -> BooleanType,
     }
 }
 
-private func GREYSetCurrentAsFailable(file: String = __FILE__, line: UInt = __LINE__) {
+private func GREYSetCurrentAsFailable(file: String = #file, line: UInt = #line) {
   let greyFailureHandlerSelector =
-  Selector("GREYFailureHandler.setInvocationFile(__FILE__, andInvocationLine:__LINE__)")
+      #selector(GREYFailureHandler.setInvocationFile(_:andInvocationLine:))
   if greyFailureHandler.respondsToSelector(greyFailureHandlerSelector) {
     greyFailureHandler.setInvocationFile!(file, andInvocationLine: line)
   }


### PR DESCRIPTION
**About `#file` and `#line`**
[Modernizing Swift's Debugging Identifiers](https://github.com/apple/swift-evolution/blob/master/proposals/0028-modernizing-debug-identifiers.md)

**About `#selector`**
[Referencing the Objective-C selector of a method](https://github.com/apple/swift-evolution/blob/master/proposals/0022-objc-selectors.md)

These styles have been introduced from Xcode 7.3 with Swift 2.2.