### PR TITLE
Fix travis builds to fail on any unexpected failures

### DIFF
--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -50,7 +50,7 @@ execute_xcodebuild() {
     # Retry condition 1: Tests haven't started.
     # We achieve that by looking for keyword "Test Suite" in xcodebuild.log.
     # FIXME: This is a brittle check and may break in future versions of Xcode. Come up with a better fix?
-    $(grep "Test Suite" xcodebuild.log)
+    $(grep -q -m 1 "Test Suite" xcodebuild.log)
     retval_test_started=$?
 
     # Re-enable exiting on command failures.
@@ -69,10 +69,9 @@ execute_xcodebuild() {
   done
 
   set +e
-  $(tail -n 200 xcodebuild.log)
   # In case of failure in test's +setUp or +tearDown, Xcode doesn't exit with an error code but logs it.
   # Add another check to make sure no unexpected failure occured.
-  $(grep "0 failures (0 unexpected)" xcodebuild.log)
+  $(grep -q -m 1 -ie ".*[1-9]\d* unexpected" xcodebuild.log)
   retval_no_expected_test_failures=$?
   set -e
 

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -72,12 +72,12 @@ execute_xcodebuild() {
   # In case of failure in test's +setUp or +tearDown, Xcode doesn't exit with an error code but logs it.
   # Add another check to make sure no unexpected failure occured.
   $(grep -q -m 1 -ie ".*[1-9]\d* unexpected" xcodebuild.log)
-  retval_no_expected_test_failures=$?
+  retval_expected_test_failures=$?
   set -e
 
   if [[ ${retval_command} -ne 0 ]]; then
     exit ${retval_command}
-  elif [[ ${is_running_test} -eq 1 ]] && [[ ${retval_no_expected_test_failures} -ne 0 ]]; then
+  elif [[ ${is_running_test} -eq 1 ]] && [[ ${retval_expected_test_failures} -eq 0 ]]; then
     exit 1
   fi
 }

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -77,7 +77,7 @@ execute_xcodebuild() {
 
   if [[ ${retval_command} -ne 0 ]]; then
     exit ${retval_command}
-  elif [[ ${is_running_test} -eq 0 ]] && [[ ${retval_no_expected_test_failures} -ne 0 ]]; then
+  elif [[ ${is_running_test} -eq 1 ]] && [[ ${retval_no_expected_test_failures} -ne 0 ]]; then
     exit 1
   fi
 }

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -50,7 +50,7 @@ execute_xcodebuild() {
     # Retry condition 1: Tests haven't started.
     # We achieve that by looking for keyword "Test Suite" in xcodebuild.log.
     # FIXME: This is a brittle check and may break in future versions of Xcode. Come up with a better fix?
-    $(grep -q "Test Suite" xcodebuild.log)
+    $(grep "Test Suite" xcodebuild.log)
     retval_test_started=$?
 
     # Re-enable exiting on command failures.
@@ -72,7 +72,7 @@ execute_xcodebuild() {
   $(tail -n 200 xcodebuild.log)
   # In case of failure in test's +setUp or +tearDown, Xcode doesn't exit with an error code but logs it.
   # Add another check to make sure no unexpected failure occured.
-  $(grep -q "0 failures (0 unexpected)" xcodebuild.log)
+  $(grep "0 failures (0 unexpected)" xcodebuild.log)
   retval_no_expected_test_failures=$?
   set -e
 

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -48,13 +48,13 @@ execute_xcodebuild() {
     # We achieve that by looking for keyword "Test Suite" in xcodebuild.log.
     # FIXME: This is a brittle check and may break in future versions of Xcode. Come up with a better fix?
     $(grep -q "Test Suite" xcodebuild.log)
-    retval_grep=$?
+    retval_test_started=$?
 
     # Re-enable exiting on command failures.
     set -e
 
     # Should we retry?
-    if [[ ${retval_test_command} -eq 65 ]] && [[ ${retval_grep} -ne 0 ]]; then
+    if [[ ${retval_test_command} -eq 65 ]] && [[ ${retval_test_started} -ne 0 ]]; then
       continue
     else
       break
@@ -70,7 +70,7 @@ execute_xcodebuild() {
 
   if [[ ${retval_test_command} -ne 0 ]]; then
     exit ${retval_test_command}
-  elif [[ ${retval_no_expected_failures} -eq 0 ]]; then
+  elif [[ ${retval_no_expected_failures} -ne 0 ]]; then
     exit 1
   fi
 }

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -64,7 +64,7 @@ execute_xcodebuild() {
   set +e
   # In case of failure in test's +setUp or +tearDown, Xcode doesn't exit with an error code but logs it.
   # Add another check to make sure no unexpected failure occured.
-  $(grep -q "0 failures \(0 unexpected\)" xcodebuild.log)
+  $(grep -q "0 failures (0 unexpected)" xcodebuild.log)
   retval_no_expected_failures=$?
   set -e
 

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -37,7 +37,7 @@ execute_xcodebuild() {
     exit 1
   fi
 
-  retval_command=0
+  local retval_command=0
   # Are we running a test?
   [[ "${ACTION}" == *"test"* ]] && is_running_test=1 || is_running_test=0
 

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -69,6 +69,7 @@ execute_xcodebuild() {
   done
 
   set +e
+  $(tail -n 200 xcodebuild.log)
   # In case of failure in test's +setUp or +tearDown, Xcode doesn't exit with an error code but logs it.
   # Add another check to make sure no unexpected failure occured.
   $(grep -q "0 failures (0 unexpected)" xcodebuild.log)


### PR DESCRIPTION
unexpected failures in +setUp or +tearDown don't count as test failures so xcode doesn't return a failure code upon exit. XCPretty also overlooks unexpected failures that arise in +setUp and +tearDown methods. The fix is to grep for "0 unexpected failures" in the final output and fail the test run if we don't find it.