### PR TITLE
Fix rspec tests broken by ruby update and changing the directory.

### DIFF
--- a/gem/spec/fixtures/tmpdir/README
+++ b/gem/spec/fixtures/tmpdir/README
@@ -1,0 +1,2 @@
+  This is an empty directory created to house temporary projects
+  that are generated on running the EarlGrey gem's rspec tests.

--- a/gem/spec/spec_helper.rb
+++ b/gem/spec/spec_helper.rb
@@ -66,9 +66,9 @@ module SpecHelper
     # dirname for "/fixtures/project_before/." => /fixtures/project_before"
     xcodeproj_2 = File.join(File.dirname(project_after), 'Example.xcodeproj')
 
-    Dir.mktmpdir do |tmp_dir|
+    begin
+      tmp_dir = File.join(project_init, '../tmpdir')
       FileUtils.cp_r project_init, tmp_dir
-
       Dir.chdir tmp_dir do
         # carthage modification of xcodeproj is non-deterministic so we can't rely on
         # comparing git diffs because the diffs are always unique... even after
@@ -88,6 +88,8 @@ module SpecHelper
           raise 'difference detected'
         end
       end
+    ensure
+      FileUtils.rm_rf(Dir.glob(File.join(tmp_dir, '*')).reject { |file| file.end_with?('README') })
     end
   end
 end


### PR DESCRIPTION
Movin' the tmp directory from something we create to a fixed one.

Required for https://github.com/google/EarlGrey/pull/305
Thanks @bootstraponline 