### PR TITLE
Updated touch injector to use a low tolerance timer

### DIFF
--- a/EarlGrey.xcodeproj/project.pbxproj
+++ b/EarlGrey.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		611BF1681D4CD292001D9E46 /* GREYDispatchQueueTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 611BF1661D4CD292001D9E46 /* GREYDispatchQueueTracker.m */; };
 		611BF16B1D4CD705001D9E46 /* GREYManagedObjectContextIdlingResource.h in Headers */ = {isa = PBXBuildFile; fileRef = 611BF1691D4CD705001D9E46 /* GREYManagedObjectContextIdlingResource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		611BF16C1D4CD705001D9E46 /* GREYManagedObjectContextIdlingResource.m in Sources */ = {isa = PBXBuildFile; fileRef = 611BF16A1D4CD705001D9E46 /* GREYManagedObjectContextIdlingResource.m */; };
+		6171EA861D9C748600FD900E /* GREYZeroToleranceTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6171EA841D9C748600FD900E /* GREYZeroToleranceTimer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6171EA871D9C748600FD900E /* GREYZeroToleranceTimer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6171EA851D9C748600FD900E /* GREYZeroToleranceTimer.m */; };
 		61CBDE801D4CD85200206BF7 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61CBDE7F1D4CD85200206BF7 /* CoreData.framework */; };
 		61E4E0B91D7559DA007F9EE6 /* GREYTouchInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 61E4E0B51D7559DA007F9EE6 /* GREYTouchInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		61E4E0BA1D7559DA007F9EE6 /* GREYTouchInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E4E0B61D7559DA007F9EE6 /* GREYTouchInfo.m */; };
@@ -211,6 +213,8 @@
 		611BF1661D4CD292001D9E46 /* GREYDispatchQueueTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GREYDispatchQueueTracker.m; sourceTree = "<group>"; };
 		611BF1691D4CD705001D9E46 /* GREYManagedObjectContextIdlingResource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GREYManagedObjectContextIdlingResource.h; sourceTree = "<group>"; };
 		611BF16A1D4CD705001D9E46 /* GREYManagedObjectContextIdlingResource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GREYManagedObjectContextIdlingResource.m; sourceTree = "<group>"; };
+		6171EA841D9C748600FD900E /* GREYZeroToleranceTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GREYZeroToleranceTimer.h; sourceTree = "<group>"; };
+		6171EA851D9C748600FD900E /* GREYZeroToleranceTimer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GREYZeroToleranceTimer.m; sourceTree = "<group>"; };
 		61CBDE7F1D4CD85200206BF7 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		61E4E0B51D7559DA007F9EE6 /* GREYTouchInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GREYTouchInfo.h; sourceTree = "<group>"; };
 		61E4E0B61D7559DA007F9EE6 /* GREYTouchInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GREYTouchInfo.m; sourceTree = "<group>"; };
@@ -659,6 +663,8 @@
 				61E4E0B61D7559DA007F9EE6 /* GREYTouchInfo.m */,
 				61E4E0B71D7559DA007F9EE6 /* GREYTouchInjector.h */,
 				61E4E0B81D7559DA007F9EE6 /* GREYTouchInjector.m */,
+				6171EA841D9C748600FD900E /* GREYZeroToleranceTimer.h */,
+				6171EA851D9C748600FD900E /* GREYZeroToleranceTimer.m */,
 			);
 			name = Event;
 			path = EarlGrey/Event;
@@ -881,6 +887,7 @@
 				597E02D71D55AC730052A8D1 /* GREYUIWebViewDelegate.h in Headers */,
 				597E02F61D55ADBE0052A8D1 /* GREYNSURLConnectionDelegate.h in Headers */,
 				61E4E0BB1D7559DA007F9EE6 /* GREYTouchInjector.h in Headers */,
+				6171EA861D9C748600FD900E /* GREYZeroToleranceTimer.h in Headers */,
 				61E4E0B91D7559DA007F9EE6 /* GREYTouchInfo.h in Headers */,
 				597E02F51D55AD8B0052A8D1 /* GREYSyntheticEvents.h in Headers */,
 				597E02D81D55AD100052A8D1 /* GREYElementProvider.h in Headers */,
@@ -1011,6 +1018,7 @@
 				FD1001F01C5B46C200B2DB0A /* UIView+GREYAdditions.m in Sources */,
 				FD10024D1C5B46C200B2DB0A /* GREYSyncAPI.m in Sources */,
 				FD1001D21C5B46C200B2DB0A /* CAAnimation+GREYAdditions.m in Sources */,
+				6171EA871D9C748600FD900E /* GREYZeroToleranceTimer.m in Sources */,
 				FD1001DE1C5B46C200B2DB0A /* NSString+GREYAdditions.m in Sources */,
 				FD1002491C5B46C200B2DB0A /* GREYNSTimerIdlingResource.m in Sources */,
 				FD6D0BA41C6D494F0001EA75 /* GREYHCMatcher.m in Sources */,

--- a/EarlGrey/Action/GREYPathGestureUtils.m
+++ b/EarlGrey/Action/GREYPathGestureUtils.m
@@ -37,7 +37,7 @@ const NSInteger kGREYScrollDetectionLength = 10;
 static const CGFloat kGREYDistanceBetweenTwoAdjacentPoints = 5.0;
 
 /**
- *  Cached screen egde pan detection length for the current device.
+ *  Cached screen edge pan detection length for the current device.
  */
 static CGFloat kCachedScreenEdgePanDetectionLength = NAN;
 

--- a/EarlGrey/Event/GREYTouchInfo.h
+++ b/EarlGrey/Event/GREYTouchInfo.h
@@ -17,6 +17,15 @@
 #import <UIKit/UIKit.h>
 
 /**
+ *  An enum for what phase of a touch action a @c GREYTouchInfo object is in.
+ */
+typedef NS_ENUM(NSUInteger, GREYTouchInfoPhase) {
+  GREYTouchInfoPhaseTouchBegan,
+  GREYTouchInfoPhaseTouchMoved,
+  GREYTouchInfoPhaseTouchEnded,
+};
+
+/**
  *  An object to encapsulate essential information about a touch.
  */
 @interface GREYTouchInfo : NSObject
@@ -25,10 +34,12 @@
  *  Points where touch should be delivered.
  */
 @property(nonatomic, readonly) NSArray *points;
+
 /**
- *  Set to YES if this is the last touch in the sequence of touches.
+ *  The phase (began, moved etc) of the touch object.
  */
-@property(nonatomic, readonly, getter=isLastTouch) BOOL lastTouch;
+@property(nonatomic, assign) GREYTouchInfoPhase phase;
+
 /**
  *  Delays this touch for specified value since the last touch delivery.
  */
@@ -56,7 +67,7 @@
  *  @return An instance of GREYTouchInfo, initialized with all required data.
  */
 - (instancetype)initWithPoints:(NSArray *)points
-                     lastTouch:(BOOL)isLastTouch
+                              phase:(GREYTouchInfoPhase)phase
     deliveryTimeDeltaSinceLastTouch:(NSTimeInterval)timeDeltaSinceLastTouchSeconds
                          expendable:(BOOL)expendable NS_DESIGNATED_INITIALIZER;
 

--- a/EarlGrey/Event/GREYTouchInfo.m
+++ b/EarlGrey/Event/GREYTouchInfo.m
@@ -19,13 +19,13 @@
 @implementation GREYTouchInfo
 
 - (instancetype)initWithPoints:(NSArray *)points
-                     lastTouch:(BOOL)isLastTouch
-    deliveryTimeDeltaSinceLastTouch:(NSTimeInterval)timeDeltaSinceLastTouchSeconds
-                         expendable:(BOOL)expendable {
+                                phase:(GREYTouchInfoPhase)phase
+      deliveryTimeDeltaSinceLastTouch:(NSTimeInterval)timeDeltaSinceLastTouchSeconds
+                           expendable:(BOOL)expendable {
   self = [super init];
   if (self) {
     _points = points;
-    _lastTouch = isLastTouch;
+    _phase = phase;
     _deliveryTimeDeltaSinceLastTouch = timeDeltaSinceLastTouchSeconds;
     _expendable = expendable;
   }

--- a/EarlGrey/Event/GREYZeroToleranceTimer.h
+++ b/EarlGrey/Event/GREYZeroToleranceTimer.h
@@ -1,0 +1,78 @@
+//
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <EarlGrey/GREYDefines.h>
+#import <UIKit/UIKit.h>
+
+@class GREYZeroToleranceTimer;
+
+/**
+ *  Protocol expected to be implemented by @c GREYZeroToleranceTimer's targets, the timer fire
+ *  event is indicated by sending the appropriate messages of this protocol to the target.
+ */
+@protocol GREYZeroToleranceTimerTarget <NSObject>
+
+@required
+/**
+ *  Invoked by @c GREYZeroToleranceTimer object when timeout fires.
+ *
+ *  @param timer The timer whose timeout fired.
+ */
+- (void)timerFiredWithZeroToleranceTimer:(GREYZeroToleranceTimer *)timer;
+
+@end
+
+/**
+ *  A high fidelity timer implementation (for example, to be used for delivering touches with
+ *  accurate timing). For example, the following code sets up the timer to fire every one second:
+ *  @code
+ *  self.timerForFoo = [[GREYZeroToleranceTimer alloc] initWithInterval:1.0 target:foo];
+ *  @endcode
+ *  Note that @c GREYZeroToleranceTimer objects create strong references to the provided targets
+ *  therefore the following is perfectly legal as well:
+ *  @code
+ *  [[GREYZeroToleranceTimer alloc] initWithInterval:1.0 target:[[FooClass alloc] init]];
+ *  @endcode
+ *  The the timer and the created FooClass object acting as a target will remain in memory until it
+ *  invalidates the timer (this can be done from the code that is invoked on the timer fire event).
+ *  Once invalidated both the timer and the object will deallocate.
+ */
+@interface GREYZeroToleranceTimer : NSObject
+
+/**
+ *  @remark init is not an available initializer. Use the other initializers.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ *  Initializes and schedules a new zero tolerance timer.
+ *
+ *  @param interval The timeout interval in seconds.
+ *  @param target   The target that should handle the timeouts. Targets must implement
+ *                  @c GREYZeroToleranceTimerTarget protocol as every time timer fires
+ *                  appropriate methods from the protocol will be invoked.
+ *
+ *  @return An initialized and scheduled timer.
+ */
+- (instancetype)initWithInterval:(CFTimeInterval)interval
+                          target:(id<GREYZeroToleranceTimerTarget>)target;
+
+/**
+ *  Invalidates the timer and cancels all future timeouts.
+ */
+- (void)invalidate;
+
+@end

--- a/EarlGrey/Event/GREYZeroToleranceTimer.m
+++ b/EarlGrey/Event/GREYZeroToleranceTimer.m
@@ -1,0 +1,77 @@
+//
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "Event/GREYZeroToleranceTimer.h"
+
+@implementation GREYZeroToleranceTimer {
+  // The target that will handle timeouts fired from this timer.
+  id<GREYZeroToleranceTimerTarget> _target;
+  // The internal dispatch timer used for firing timeouts.
+  dispatch_source_t _timer;
+}
+
+- (instancetype)initWithInterval:(CFTimeInterval)interval
+                          target:(id<GREYZeroToleranceTimerTarget>)target {
+  NSParameterAssert(target);
+  self = [super init];
+  if (self) {
+    _target = target;
+    _timer = [GREYZeroToleranceTimer scheduleZeroToleranceTimerWithInterval:interval
+                                                                    handler:^{
+      [_target timerFiredWithZeroToleranceTimer:self];
+    }];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [self invalidate];
+}
+
+- (void)invalidate {
+  if (_timer) {
+    dispatch_source_cancel(_timer);
+    _timer = nil;
+  }
+  _target = nil;
+}
+
+/**
+ *  Schedules a zero tolerance dispatch timer with the given interval and timeout handler.
+ *
+ *  @param interval The interval in seconds from current time for the timer to fire in.
+ *  @param handler  The handler to be invoked on timeout.
+ *
+ *  @return A dispatch_source_t pointing to the newly created timer.
+ */
++ (dispatch_source_t)scheduleZeroToleranceTimerWithInterval:(CFTimeInterval)interval
+                                                    handler:(void(^)())handler {
+  dispatch_source_t timer =
+      dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+  NSAssert(timer, @"Timer could not be created");
+  dispatch_time_t fireTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(interval * NSEC_PER_SEC));
+  dispatch_source_set_timer(timer,
+                            fireTime,
+                            (uint64_t)(interval * NSEC_PER_SEC),
+                            (uint64_t)(0));
+  dispatch_source_set_event_handler(timer, ^{
+    handler();
+  });
+  dispatch_resume(timer);
+  return timer;
+}
+
+@end

--- a/Tests/UnitTests/Sources/GREYTouchInjectorTest.m
+++ b/Tests/UnitTests/Sources/GREYTouchInjectorTest.m
@@ -40,7 +40,7 @@
 - (GREYTouchInfo *)touchInfoWithTimeDelta:(CFTimeInterval)delta
                              expendable:(BOOL)expendable {
   return [[GREYTouchInfo alloc] initWithPoints:@[[NSValue valueWithCGPoint:CGPointZero]]
-                                     lastTouch:NO
+                                         phase:GREYTouchInfoPhaseTouchBegan
                deliveryTimeDeltaSinceLastTouch:delta
                                     expendable:expendable];
 }


### PR DESCRIPTION
Updated touch injector to use a low tolerance timer instead of display link to better work on slow machines (net effect observed is a reduction of avg test time and increased test pass (to falky fail) ratio).
