### PR TITLE
Fix broken Ruby test for Carthage

### DIFF
--- a/gem/spec/fixtures/carthage_after/Example.xcodeproj/project.pbxproj
+++ b/gem/spec/fixtures/carthage_after/Example.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
 			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			showEnvVarsInLog = 1;
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
It looks like showEnvVarsInLog if turned on is not modified in the Xcode Project. On running the spec tests for Carthage, the value is set as 1, which is correct. Adding this value in the spec project.