### PR TITLE
Add a Swift Test for Setting / Asserting Dates on a Date Picker

### DIFF
--- a/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
+++ b/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
@@ -194,6 +194,20 @@ class FunctionalTestRigSwiftTests: XCTestCase {
     }
   }
 
+  func testChangingDatePickerToAFutureDate() {
+    self.openTestView("Picker Views")
+    // Have an arbitrary date created
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateStyle = .medium
+    let date = Date(timeIntervalSinceReferenceDate: 118800)
+    dateFormatter.locale = Locale(identifier: "en_US")
+    EarlGrey.select(elementWithMatcher: grey_text("Date")).perform(grey_tap())
+    EarlGrey.select(elementWithMatcher: grey_accessibilityID("DatePickerId"))
+      .perform(grey_setDate(date))
+    EarlGrey.select(elementWithMatcher: grey_accessibilityID("DatePickerId"))
+      .assert(grey_datePickerValue(date))
+  }
+
   func waitForWebElementWithName(_ name: String, elementMatcher matcher: GREYMatcher) {
     GREYCondition(name: name + " Condition", block: {_ in
       var errorOrNil: NSError?


### PR DESCRIPTION
I have a request from @akalidas on Slack to add a Swift test for doing this since it seems to be a little un-intuitive. Adding a date picker test in Swift.