### PR TITLE
[CI SKIP] Updated CHANGELOG and podspec for 1.5.2 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 Details changes in each release of EarlGrey. EarlGrey follows
 [semantic versioning](http://semver.org/).
 
+## [1.5.2](https://github.com/google/EarlGrey/tree/1.5.2) (11/11/2016)
+
+```
+Baseline: [f3ee931]
+   + [f3ee931]: Updated ChangeLog and pod spec for 1.5.2 release
+```
+
+### Compatibility
+* Handle bit-dependent CGFloat with bit-dependent trig function
+
+### Enhancements
+* Enhance precision of timer used for touch injection
+* Removed requirement for bridging header for Swift and EarlGrey
+
 ## [1.5.1](https://github.com/google/EarlGrey/tree/1.5.1) (11/07/2016)
 
 ```

--- a/EarlGrey-Info.plist
+++ b/EarlGrey-Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.1</string>
+	<string>1.5.2</string>
 	<key>CFBundleVersion</key>
-	<string>1.5.1</string>
+	<string>1.5.2</string>
 	<key>license</key>
 	<string>
 

--- a/EarlGrey.podspec.json
+++ b/EarlGrey.podspec.json
@@ -18,7 +18,7 @@
 // frameworks in the app bundle need to include bitcode.
 {
   "name": "EarlGrey",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "summary": "iOS UI Automation Test Framework",
   "description": "EarlGrey is a native iOS UI automation test framework that enables you to write clear, concise tests.\\n\\nWith the EarlGrey framework, you have access to enhanced synchronization features. EarlGrey automatically synchronizes with the UI, network requests, and various queues, but still allows you to manually implement customized timings, if needed.\\n\\nEarlGrey’s synchronization features help ensure that the UI is in a steady state before actions are performed. This greatly increases test stability and makes tests highly repeatable.\\n\\nEarlGrey works in conjunction with the XCTest framework and integrates with Xcode’s Test Navigator so you can run tests directly from Xcode or the command line (using xcodebuild).",
   "homepage": "http://google.github.io/EarlGrey",

--- a/EarlGrey.podspec.json
+++ b/EarlGrey.podspec.json
@@ -34,7 +34,7 @@
   },
   "requires_arc": true,
   "source": {
-    "http": "http://www.github.com/google/EarlGrey/releases/download/1.5.1/EarlGrey.zip"
+    "http": "http://www.github.com/google/EarlGrey/releases/download/1.5.2/EarlGrey.zip"
   },
   "frameworks": [
     "CoreData",

--- a/gem/lib/earlgrey/version.rb
+++ b/gem/lib/earlgrey/version.rb
@@ -14,5 +14,5 @@
 #  limitations under the License.
 
 module EarlGrey
-  VERSION = '0.1.1'.freeze unless defined? ::EarlGrey::VERSION
+  VERSION = '0.1.2'.freeze unless defined? ::EarlGrey::VERSION
 end


### PR DESCRIPTION
This is for 1.5.2 release for cocoapods and gem.