### PR TITLE
fix rubocop warning

### DIFF
--- a/gem/Gemfile
+++ b/gem/Gemfile
@@ -17,5 +17,5 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'thor' # enable: bundle exec thor spec
 gem 'coveralls', require: false
+gem 'thor' # enable: bundle exec thor spec


### PR DESCRIPTION
Gemfile:21:1: C: Bundler/OrderedGems: Gem coveralls should appear before thor in their gem group.
gem 'coveralls', require: false
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^