### PR TITLE
Synching some changes from internal repo to github

### DIFF
--- a/EarlGrey/Action/GREYPathGestureUtils.h
+++ b/EarlGrey/Action/GREYPathGestureUtils.h
@@ -69,18 +69,13 @@
 
 /**
  *  Generates a touch path in the @c window from the given @c startPoint and the given @c
- *  endPoint. Based on the @c GREYPinchDirection two such touch paths are required to generate pinch
- *  gesture. If the pinch direction is @c kGREYPinchDirectionOutward then two touch paths have
- *  starting points as the center of the view under test and ending points are on circle having
- *  touch path as the radius. Similarly when pinch direction is @c kGREYPinchDirectionInward then
- *  two touch paths have starting points on the circle having touch path as the radius and
- *  ending points are the center of the the view under test.
+ *  endPoint.
  *
  *  @param startPoint The starting point for touch path.
  *  @param endPoint   The end point for touch path
  *
  *  @return NSArray of CGPoints that denote the points in the touch path.
  */
-+ (NSArray *)touchPathForPinchGestureWithStartPoint:(CGPoint)startPoint
-                                        andEndPoint:(CGPoint)endPoint;
++ (NSArray *)touchPathForDragGestureWithStartPoint:(CGPoint)startPoint
+                                       andEndPoint:(CGPoint)endPoint;
 @end

--- a/EarlGrey/Action/GREYPathGestureUtils.m
+++ b/EarlGrey/Action/GREYPathGestureUtils.m
@@ -63,8 +63,8 @@ static CGFloat kCachedScreenEdgePanDetectionLength = NAN;
                         shouldCancelInertia:NO];
 }
 
-+ (NSArray *)touchPathForPinchGestureWithStartPoint:(CGPoint)startPoint
-                                        andEndPoint:(CGPoint)endPoint {
++ (NSArray *)touchPathForDragGestureWithStartPoint:(CGPoint)startPoint
+                                       andEndPoint:(CGPoint)endPoint {
   return [self grey_touchPathWithStartPoint:startPoint
                                    endPoint:endPoint
                         shouldCancelInertia:YES];

--- a/EarlGrey/Action/GREYPinchAction.m
+++ b/EarlGrey/Action/GREYPinchAction.m
@@ -148,12 +148,20 @@ static double const kDefaultPinchAngle = (30.0 * M_PI / 180.0);
       endPoint2 = centerPoint;
       break;
   }
+
+  // Based on the @c GREYPinchDirection two touch paths are required to generate a pinch gesture
+  // If the pinch direction is @c kGREYPinchDirectionOutward then the two touch paths have their
+  // starting points as the center of the view for the gesture and the ending points are on the
+  // circle having the touch path as the radius. Similarly when pinch direction is
+  // @c kGREYPinchDirectionInward then the two touch paths have starting points on the circle
+  // having the touch path as the radius and ending points are the center of the the view under
+  // test.
   NSArray *touchPathInDirection1 =
-      [GREYPathGestureUtils touchPathForPinchGestureWithStartPoint:startPoint1
-                                                       andEndPoint:endPoint1];
+      [GREYPathGestureUtils touchPathForDragGestureWithStartPoint:startPoint1
+                                                      andEndPoint:endPoint1];
   NSArray *touchPathInDirection2 =
-      [GREYPathGestureUtils touchPathForPinchGestureWithStartPoint:startPoint2
-                                                       andEndPoint:endPoint2];
+      [GREYPathGestureUtils touchPathForDragGestureWithStartPoint:startPoint2
+                                                      andEndPoint:endPoint2];
 
   [GREYSyntheticEvents touchAlongMultiplePaths:@[ touchPathInDirection1, touchPathInDirection2 ]
                               relativeToWindow:window

--- a/EarlGrey/Additions/CGGeometry+GREYAdditions.h
+++ b/EarlGrey/Additions/CGGeometry+GREYAdditions.h
@@ -179,6 +179,21 @@ CGRect CGRectFixedToVariableScreenCoordinates(CGRect rectInFixedCoordinates);
 CGRect CGRectVariableToFixedScreenCoordinates(CGRect rectInVariableCoordinates);
 
 /**
+ *  Return the intersection of @c rect1 and @c rect2. The built-in function can produce floating
+ *  errors on 32-bit platform (i.e. iphone 5), which results in a bigger rectangle than both
+ *  sources. This will remove the errors by forcing the resulting rectangle to be no greater than
+ *  the sources.
+ *
+ *  @param rect1 The first source rectangle.
+ *  @param rect2 The second source rectangle.
+ *
+ *  @return A rectangle that represents the intersection of the two specified rectangles. If the two
+ *          rectangles do not intersect, returns the null rectangle. To check for this condition,
+ *          use CGRectIsNull.
+ */
+CGRect CGRectIntersectionStrict(CGRect rect1, CGRect rect2);
+
+/**
  *  Normalizes @c rectInPixels to the largest rectangle that is within rectInPixels and
  *  pixel-boundary aligned. If the fractional part of height or width are > 0.5, they are rounded up
  *  otherwise rounded down.

--- a/EarlGrey/Additions/CGGeometry+GREYAdditions.m
+++ b/EarlGrey/Additions/CGGeometry+GREYAdditions.m
@@ -169,6 +169,19 @@ CGRect CGRectVariableToFixedScreenCoordinates(CGRect rectInVariableCoordinates) 
   return rectInFixedCoordinates;
 }
 
+CGRect CGRectIntersectionStrict(CGRect rect1, CGRect rect2) {
+  CGRect rect = CGRectIntersection(rect1, rect2);
+#if !CGFLOAT_IS_DOUBLE
+  // CGRectGetWidth and CGRectGetHeight will return normalized results, this will ensure the
+  // resulting rect is no greater than the given sources
+  rect.size.width = MIN(CGRectGetWidth(rect),
+                        MIN(CGRectGetWidth(rect1), CGRectGetWidth(rect2)));
+  rect.size.height = MIN(CGRectGetHeight(rect),
+                         MIN(CGRectGetHeight(rect1), CGRectGetHeight(rect2)));
+#endif
+  return rect;
+}
+
 CGRect CGRectIntegralInside(CGRect rectInPixels) {
   CGFloat minXFraction = CGRectGetMinX(rectInPixels) - grey_floor(CGRectGetMinX(rectInPixels));
   // Adjust horizontal pixel boundary alignment.
@@ -194,13 +207,9 @@ CGRect CGRectIntegralInside(CGRect rectInPixels) {
     rectInPixels.origin.y = grey_floor(CGRectGetMinY(rectInPixels));
   }
 
-  CGFloat widthFraction = rectInPixels.size.width - grey_floor(rectInPixels.size.width);
-  CGFloat heightFraction = rectInPixels.size.height - grey_floor(rectInPixels.size.height);
   // Pixel-align width and height as per iOS implementation.
-  rectInPixels.size.width = widthFraction > 0.5 ? grey_ceil(rectInPixels.size.width) :
-      grey_floor(rectInPixels.size.width);
-  rectInPixels.size.height = heightFraction > 0.5 ? grey_ceil(rectInPixels.size.height) :
-      grey_floor(rectInPixels.size.height);
+  rectInPixels.size.width = grey_ceil(rectInPixels.size.width - 0.5);
+  rectInPixels.size.height = grey_ceil(rectInPixels.size.height - 0.5);
   return rectInPixels;
 }
 

--- a/EarlGrey/Common/GREYVisibilityChecker.m
+++ b/EarlGrey/Common/GREYVisibilityChecker.m
@@ -543,8 +543,8 @@ inline void GREYVisibilityDiffBufferSetVisibilityAt(GREYVisibilityDiffBuffer buf
   CGRect screenBounds = [[UIScreen mainScreen] bounds];
   CGRect axFrame = [view accessibilityFrame];
   CGRect searchRectOnScreenInViewInScreenCoordinates =
-      CGRectIntersection(searchRectInScreenCoordinates,
-                         CGRectIntersection(axFrame, screenBounds));
+      CGRectIntersectionStrict(searchRectInScreenCoordinates,
+                               CGRectIntersectionStrict(axFrame, screenBounds));
   if (CGRectIsEmpty(searchRectOnScreenInViewInScreenCoordinates)) {
     return NO;
   }

--- a/Tests/FunctionalTests/Sources/FTRAlertViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRAlertViewTest.m
@@ -54,8 +54,7 @@
       performAction:[GREYActions actionForTap]];
 }
 
-//TODO: Investigate this flaky test.
-- (void)DISABLED_testStyledAlertView {
+- (void)testStyledAlertView {
   [[EarlGrey selectElementWithMatcher:grey_text(@"Styled Alert")]
       performAction:[GREYActions actionForTap]];
 

--- a/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
+++ b/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
@@ -128,20 +128,11 @@ class FunctionalTestRigSwiftTests: XCTestCase {
     GREYAssert(textFieldEventsRecorder.verify(), reason: "Text field events were not all received")
   }
 
-  func testFastTypingOnWebView() {
-    self.openTestView("Web Views")
-    EarlGrey.select(elementWithMatcher: grey_accessibilityLabel("loadGoogle"))
-      .perform(grey_tap())
-    let searchButtonMatcher: GREYMatcher = grey_accessibilityHint("Search")
-
-    self.waitForWebElementWithName("Search Button", elementMatcher: searchButtonMatcher)
-
-    // grey_text() doesn't work on webviews, must use grey_accessibilityValue()
-    EarlGrey.select(elementWithMatcher: searchButtonMatcher)
-      .perform(grey_clearText())
-      .perform(grey_typeText("zzz"))
-      .perform(grey_replaceText("new_text_value"))
-      .assert(grey_accessibilityValue("new_text_value"))
+  func testTypingWithDeletion() {
+    self.openTestView("Typing Views")
+    EarlGrey.select(elementWithMatcher: grey_accessibilityID("TypingTextField"))
+      .perform(grey_typeText("Fooo\u{8}B\u{8}Bar"))
+      .assert(grey_text("FooBar"))
   }
 
   func testButtonPressWithGREYAllOf() {
@@ -207,15 +198,6 @@ class FunctionalTestRigSwiftTests: XCTestCase {
       .perform(grey_setDate(date))
     EarlGrey.select(elementWithMatcher: grey_accessibilityID("DatePickerId"))
       .assert(grey_datePickerValue(date))
-  }
-
-  func waitForWebElementWithName(_ name: String, elementMatcher matcher: GREYMatcher) {
-    GREYCondition(name: name + " Condition", block: {_ in
-      var errorOrNil: NSError?
-      EarlGrey.select(elementWithMatcher: matcher)
-        .assert(grey_sufficientlyVisible(), error: &errorOrNil)
-      return errorOrNil == nil
-    }).wait(withTimeout: 3.0)
   }
 
   func openTestView(_ name: String) {

--- a/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
+++ b/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
@@ -69,7 +69,7 @@ class TextFieldEventsRecorder {
   @objc func editingDidEndHandler() { editingDidEnd = true }
 }
 
-class FunctionalTestRigSwiftTests: XCTestCase {
+class FTRSwiftTests: XCTestCase {
 
   override func tearDown() {
     super.tearDown()

--- a/docs/install-and-run.md
+++ b/docs/install-and-run.md
@@ -42,8 +42,8 @@ For EarlGrey, we highly recommend [CocoaPods](https://cocoapods.org/) as the bes
   1. After your test target (for example, *SampleAppTests*) is set up, you now need to add EarlGrey as
   a framework dependency. To do so, add EarlGrey as a dependency to the test target in your `Podfile`.
   2. Because EarlGrey must be embedded within the app under test, we need to add certain Build Phases and
-  Scheme changes to the **Test Target**. We recommend using our earlgrey gem to install any dependencies if you're using a CocoaPods version from `1.0.0` onwards. Run `gem install earlgrey`. In case you are using an earlier version of the EarlGrey CocoaPod, please use the corresponding version of the EarlGrey gem from the info provided [here](https://github.com/google/EarlGrey/tree/master/docs/versions.md) and specify the version with `gem install earlgrey -v x.y.z`.
-  
+  Scheme changes to the **Test Target**. We recommend using our earlgrey gem to install any dependencies. You can use it by running `gem install earlgrey`. In case you are using an earlier version of the EarlGrey CocoaPod, please peruse this [doc](https://github.com/google/EarlGrey/tree/master/docs/versions.md) to find the corresponding EarlGrey gem version and any syntax changes. To download a particular version of the gem, use `gem install earlgrey -v x.y.z`.
+
   You need to require this gem in a post_install hook using the project's name, the test target's name, and the name of the xcscheme file as is shown in the below example for `1.0.0`:
 
   ```ruby

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,19 +1,19 @@
-EarlGrey Releases and their corresponding EarlGrey Gem Versions. The provided gem version is **not**
-the last compatible EarlGrey gem version for a release, but the gem version that was either released with the CocoaPod or
-with which the CocoaPod was tested for release.
+This table enumerates the different EarlGrey releases, the recommended version of the EarlGrey gem to use with them and the minimum supported CocoaPods version.
+
+In case you are using the 0.39.0 CocoaPods version, prefer to an older version of our EarlGrey installation instructions, provided [here](https://github.com/google/EarlGrey/tree/c37b01dc8047ed02746f9dc67eec75816565aa48/docs/install-and-run.md#step-2-add-earlgrey-as-a-framework-dependency).
 
 
-EarlGrey Release Version                                       | Corresponding EarlGrey Gem Version
----------------------------------------------------------------|---------------------------------------------------------------
-[1.0.0](https://github.com/google/EarlGrey/releases/tag/1.0.0) | [0.0.8](https://rubygems.org/gems/earlgrey/versions/0.0.8)
-[1.1.0](https://github.com/google/EarlGrey/releases/tag/1.1.0) | [0.0.9](https://rubygems.org/gems/earlgrey/versions/0.0.9)     
-[1.2.0](https://github.com/google/EarlGrey/releases/tag/1.2.0) | [0.0.10](https://rubygems.org/gems/earlgrey/versions/0.0.10)
-[1.3.0](https://github.com/google/EarlGrey/releases/tag/1.3.0) | [0.0.11](https://rubygems.org/gems/earlgrey/versions/0.0.11)
-[1.3.1](https://github.com/google/EarlGrey/releases/tag/1.3.1) | [0.0.13](https://rubygems.org/gems/earlgrey/versions/0.0.13)
-[1.4.0](https://github.com/google/EarlGrey/releases/tag/1.4.0) | [0.0.14](https://rubygems.org/gems/earlgrey/versions/0.0.14)
-[1.5.0](https://github.com/google/EarlGrey/releases/tag/1.5.0) | [0.1.0](https://rubygems.org/gems/earlgrey/versions/0.1.0)
-[1.5.1](https://github.com/google/EarlGrey/releases/tag/1.5.1) | [0.1.0](https://rubygems.org/gems/earlgrey/versions/0.1.0)
-[1.5.2](https://github.com/google/EarlGrey/releases/tag/1.5.2) | [0.1.1](https://rubygems.org/gems/earlgrey/versions/0.1.1)
-[1.5.3](https://github.com/google/EarlGrey/releases/tag/1.5.3) | [0.1.1](https://rubygems.org/gems/earlgrey/versions/0.1.1)
-[1.6.0](https://github.com/google/EarlGrey/releases/tag/1.6.0) | [0.1.3](https://rubygems.org/gems/earlgrey/versions/0.1.3)
-[1.6.1](https://github.com/google/EarlGrey/releases/tag/1.6.1) | [0.1.4](https://rubygems.org/gems/earlgrey/versions/0.1.4)
+EarlGrey Release Version                                       | Corresponding EarlGrey Gem Version                            | Minimum Supported CocoaPods Version
+---------------------------------------------------------------|---------------------------------------------------------------|---------------------------------------------------------------
+[1.0.0](https://github.com/google/EarlGrey/releases/tag/1.0.0) | [0.0.8](https://rubygems.org/gems/earlgrey/versions/0.0.8) | 0.39.0
+[1.1.0](https://github.com/google/EarlGrey/releases/tag/1.1.0) | [0.0.9](https://rubygems.org/gems/earlgrey/versions/0.0.9) | 1.0.0
+[1.2.0](https://github.com/google/EarlGrey/releases/tag/1.2.0) | [0.0.10](https://rubygems.org/gems/earlgrey/versions/0.0.10) | 1.0.0
+[1.3.0](https://github.com/google/EarlGrey/releases/tag/1.3.0) | [0.0.11](https://rubygems.org/gems/earlgrey/versions/0.0.11) | 1.0.0
+[1.3.1](https://github.com/google/EarlGrey/releases/tag/1.3.1) | [0.0.13](https://rubygems.org/gems/earlgrey/versions/0.0.13) | 1.0.0
+[1.4.0](https://github.com/google/EarlGrey/releases/tag/1.4.0) | [0.0.14](https://rubygems.org/gems/earlgrey/versions/0.0.14) | 1.0.0
+[1.5.0](https://github.com/google/EarlGrey/releases/tag/1.5.0) | [0.1.0](https://rubygems.org/gems/earlgrey/versions/0.1.0) | 1.0.0
+[1.5.1](https://github.com/google/EarlGrey/releases/tag/1.5.1) | [0.1.0](https://rubygems.org/gems/earlgrey/versions/0.1.0) | 1.0.0
+[1.5.2](https://github.com/google/EarlGrey/releases/tag/1.5.2) | [0.1.1](https://rubygems.org/gems/earlgrey/versions/0.1.1) | 1.0.0
+[1.5.3](https://github.com/google/EarlGrey/releases/tag/1.5.3) | [0.1.1](https://rubygems.org/gems/earlgrey/versions/0.1.1) | 1.0.0
+[1.6.0](https://github.com/google/EarlGrey/releases/tag/1.6.0) | [0.1.3](https://rubygems.org/gems/earlgrey/versions/0.1.3) | 1.0.0
+[1.6.1](https://github.com/google/EarlGrey/releases/tag/1.6.1) | [0.1.4](https://rubygems.org/gems/earlgrey/versions/0.1.4) | 1.0.0


### PR DESCRIPTION
Commits in this PR:

- Add a helper method for CGRectIntersection which fixes a bug on 32-bit platform (i.e. iphone 5 and prior) that results in larger rectangles than the two sources
- Recommend the gem and cocoapod version to use with each EarlGrey release
- Change the name for GREYPathGestureUtils for the drag action.
- Re-enable FTRAlertViewTest's testStyledAlertViews as it runs fine.
- Remove webtest for swift and add Swift Tests for typing backspace