### PR TITLE
Update Info.plist to use PRODUCT_BUNDLE_IDENTIFIER.

### DIFF
--- a/EarlGrey-Info.plist
+++ b/EarlGrey-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>${BUNDLE_IDENTIFIER}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Github import of changes:

  - Update Info.plist to use PRODUCT_BUNDLE_IDENTIFIER instead of
    BUNDLE_IDENTIFIER. Without this, XCUITest throws an error that
    CFBundleIdentifier is not available in EarlGrey.framework.

PiperOrigin-RevId: 144740736