### PR TITLE
Originally EarlGrey's analytics included the following:

### DIFF
--- a/EarlGrey/Common/GREYAnalytics.m
+++ b/EarlGrey/Common/GREYAnalytics.m
@@ -45,8 +45,6 @@ static NSString *const kTrackingEndPoint = @"https://ssl.google-analytics.com";
   __weak id<GREYAnalyticsDelegate> _delegate;
   // Once set, analytics will be sent on next XCTestCase tearDown.
   BOOL _earlgreyWasCalledInXCTestContext;
-  // Test case counter used for counting testcases
-  unsigned int _testCaseCounter;
 }
 
 + (void)initialize {
@@ -70,7 +68,6 @@ static NSString *const kTrackingEndPoint = @"https://ssl.google-analytics.com";
   if (self) {
     _delegate = nil;
     _earlgreyWasCalledInXCTestContext = NO;
-    _testCaseCounter = 0;
     // Register as an observer for kGREYXCTestCaseInstanceDidTearDown.
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(grey_testCaseInstanceDidTearDown)
@@ -167,7 +164,6 @@ static NSString *const kTrackingEndPoint = @"https://ssl.google-analytics.com";
   if (_earlgreyWasCalledInXCTestContext) {
     // Reset var to track multiple test case invocations.
     _earlgreyWasCalledInXCTestContext = NO;
-    _testCaseCounter += 1;
 
     if (GREY_CONFIG_BOOL(kGREYConfigKeyAnalyticsEnabled)) {
       NSString *bundleIDMD5 = [[[NSBundle mainBundle] bundleIdentifier] grey_md5String];
@@ -175,7 +171,12 @@ static NSString *const kTrackingEndPoint = @"https://ssl.google-analytics.com";
         // If bundle ID is not available we use a placeholder.
         bundleIDMD5 = @"<Missing Bundle ID>";
       }
-      NSString *subCategory = [NSString stringWithFormat:@"TestCase_%u", _testCaseCounter];
+      XCTestCase *testCase = [XCTestCase grey_currentTestCase];
+      NSString *testCaseMD5 =
+          [[NSString stringWithFormat:@"%@::%@",
+                                      [testCase grey_testClassName],
+                                      [testCase grey_testMethodName]] grey_md5String];
+      NSString *subCategory = [NSString stringWithFormat:@"TestCase_%@", testCaseMD5];
       [self.delegate trackEventWithTrackingID:kGREYAnalyticsTrackingID
                                      category:bundleIDMD5
                                   subCategory:subCategory

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ or request to join our [slack channel](https://googleoss.slack.com/messages/earl
 
 To prioritize and improve EarlGrey, the framework collects usage data and
 uploads it to Google Analytics. More specifically, the framework collects the
-App’s *Bundle ID* (as a MD5 hash) and the total number of test cases. This
+**MD5 hash** of *Bundle ID*,  *Test Class Names* and *Test Method Names*. This
 information allows us to measure the volume of usage. For more detailed
 information about our analytics collection, please peruse the
 [GREYAnalytics.m](https://github.com/google/EarlGrey/tree/master/EarlGrey/Common/GREYAnalytics.m)
-file which contains the implementation details. If they wish,
-users can choose to opt out by disabling the Analytics config setting in their
-test’s `- (void)setUp` method:
+file which contains the implementation details. If they wish, users can choose
+to opt out by disabling the Analytics config setting in their test’s
+`- (void)setUp` method:
 
 In Objective-C:
 ```objc


### PR DESCRIPTION
Github import of changes:

  - Originally EarlGrey's analytics included the following:
    1. MD5 Hash of bundle ID
    2. The formatted string: "TestCase_{counter}" where counter incremented
       for every test case.
    This design has the problem that if the test execution was sharded
    (run smaller sets of tests in parallel) analytics would end up
    getting a count of test cases *per shard* instead of the *total*
    count of testcases. Solution to this problem is to use a hash of
    "{Test Class Name} + {Test Method Name}", since that is unique for
    every test case we can anonymously (because of the hash)
    collect *total* count of test cases even if they were sharded.
    As a result the data we collect now is:
    1. MD5 Hash of bundle ID
    2. MD5 Hash of Test Class Names
    3. MD5 Hash of Test Method Names

Also updated the README.md's analytics section to reflect this.

PiperOrigin-RevId: 144864338