### PR TITLE
Using custom text matcher instead of hasProperty because hasProperty …

### DIFF
--- a/EarlGrey/Matcher/GREYMatchers.m
+++ b/EarlGrey/Matcher/GREYMatchers.m
@@ -145,13 +145,13 @@ static const double kElementSufficientlyVisiblePercentage = 0.75;
                     nil);
 }
 
-+ (id<GREYMatcher>)matcherForAccessibilityHint:(NSString *)hint {
++ (id<GREYMatcher>)matcherForAccessibilityHint:(id)hint {
   MatchesBlock matches = ^BOOL(NSObject *element) {
-    if (element.accessibilityHint == hint) {
+    id accessibilityHint = element.accessibilityHint;
+    if (accessibilityHint == hint) {
       return YES;
     }
-    return [self grey_accessibilityString:element.accessibilityHint
-             isEqualToAccessibilityString:hint];
+    return [self grey_accessibilityString:accessibilityHint isEqualToAccessibilityString:hint];
   };
   DescribeToBlock describe = ^void(id<GREYDescription> description) {
     [description appendText:[NSString stringWithFormat:@"accessibilityHint(\"%@\")", hint]];
@@ -176,10 +176,19 @@ static const double kElementSufficientlyVisiblePercentage = 0.75;
 }
 
 + (id<GREYMatcher>)matcherForText:(NSString *)text {
+  MatchesBlock matches = ^BOOL(id element) {
+    return [[element text] isEqualToString:text];
+  };
+  DescribeToBlock describe = ^void(id<GREYDescription> description) {
+    [description appendText:[NSString stringWithFormat:@"hasText('%@')", text]];
+  };
+  id<GREYMatcher> matcher = [[GREYElementMatcherBlock alloc] initWithMatchesBlock:matches
+                                                                 descriptionBlock:describe];
   return grey_allOf(grey_anyOf(grey_kindOfClass([UILabel class]),
                                grey_kindOfClass([UITextField class]),
                                grey_kindOfClass([UITextView class]), nil),
-                    hasProperty(@"text", text), nil);
+                    matcher,
+                    nil);
 }
 
 + (id<GREYMatcher>)matcherForFirstResponder {

--- a/Tests/UnitTests/Sources/GREYMatchersTest.m
+++ b/Tests/UnitTests/Sources/GREYMatchersTest.m
@@ -335,18 +335,23 @@
   XCTAssertFalse([focusMatcher matches:customUIView], @"View should not be focused");
 }
 
-- (void)testMatchingTestPass {
+- (void)testTextMatcherPass {
   UILabel *testLabel = [[UILabel alloc] init];
   [testLabel setText:@"display text"];
   id<GREYMatcher> textMatcher = grey_text(@"display text");
   XCTAssertTrue([textMatcher matches:testLabel], @"Matching text should return true");
 }
 
-- (void)testMatchingTestFail {
+- (void)testTextMatcherFail {
   UILabel *testLabel = [[UILabel alloc] init];
   [testLabel setText:@"display text"];
+  id<GREYDescription> failureDesc = [[GREYStringDescription alloc] init];
   id<GREYMatcher> textMatcher = grey_text(@"incorrect display text");
-  XCTAssertFalse([textMatcher matches:testLabel], @"Non-matching text should return false");
+  XCTAssertFalse([textMatcher matches:testLabel describingMismatchTo:failureDesc],
+                 @"Non-matching text should return false");
+  NSRange failureMessageRange =
+      [[failureDesc description] rangeOfString:@"hasText('incorrect display text')"];
+  XCTAssertNotEqual(failureMessageRange.location, NSNotFound);
 }
 
 - (void)testBadObjectTypeFail {


### PR DESCRIPTION
…formats the description differently and it looks bad with the new error message logs.

Github import of changes:

  - Using custom text matcher instead of hasProperty because hasProperty formats the description differently and it looks bad with the new error message logs.

Old one shown as: an object with text "l0rem.ipsum+42@google.com#*-")
New one shown as: hasText('l0rem.ipsum+42@google.com#*-')

PiperOrigin-RevId: 145150301