### PR TITLE
Improving error reporting for failures caused by thread executor timeouts.

### DIFF
--- a/EarlGrey/Additions/NSObject+GREYAdditions.m
+++ b/EarlGrey/Additions/NSObject+GREYAdditions.m
@@ -311,7 +311,7 @@ static Class gWebAccessibilityWrapper;
       // As a safeguard, track the pending call for twice the amount incase the execution is
       // *really* delayed (due to cpu trashing) for more than the expected execution-time.
       // The custom selector will stop tracking as soon as it is triggered.
-      NSString *trackerName = [NSString stringWithFormat:@"performSelector %@ on %@",
+      NSString *trackerName = [NSString stringWithFormat:@"performSelector @selector(%@) on %@",
                                   NSStringFromSelector(aSelector), NSStringFromClass([self class])];
       // For negative delays use 0.
       NSTimeInterval nonNegativeDelay = MAX(0, 2 * delay);

--- a/EarlGrey/Additions/NSString+GREYAdditions.h
+++ b/EarlGrey/Additions/NSString+GREYAdditions.h
@@ -36,9 +36,4 @@
  */
 - (NSString *)grey_md5String;
 
-/**
- *  @return a JSON in the escaped format of the given input @c string.
- */
-- (NSString *)grey_JSONEscape;
-
 @end

--- a/EarlGrey/Additions/NSString+GREYAdditions.m
+++ b/EarlGrey/Additions/NSString+GREYAdditions.m
@@ -41,38 +41,4 @@
   return [stringWithHexMd5Values copy];
 }
 
-- (NSString *)grey_JSONEscape {
-  NSMutableString *escaped = [NSMutableString stringWithString:self];
-  [escaped replaceOccurrencesOfString:@"\""
-                     withString:@"\\\""
-                              options:NSCaseInsensitiveSearch
-                                range:NSMakeRange(0, [escaped length])];
-  [escaped replaceOccurrencesOfString:@"/"
-                           withString:@"\\/"
-                              options:NSCaseInsensitiveSearch
-                                range:NSMakeRange(0, [escaped length])];
-  [escaped replaceOccurrencesOfString:@"\n"
-                           withString:@"\\n"
-                              options:NSCaseInsensitiveSearch
-                                range:NSMakeRange(0, [escaped length])];
-  [escaped replaceOccurrencesOfString:@"\b"
-                           withString:@"\\b"
-                              options:NSCaseInsensitiveSearch
-                                range:NSMakeRange(0, [escaped length])];
-  [escaped replaceOccurrencesOfString:@"\f"
-                           withString:@"\\f"
-                              options:NSCaseInsensitiveSearch
-                                range:NSMakeRange(0, [escaped length])];
-  [escaped replaceOccurrencesOfString:@"\r"
-                           withString:@"\\r"
-                              options:NSCaseInsensitiveSearch
-                                range:NSMakeRange(0, [escaped length])];
-  [escaped replaceOccurrencesOfString:@"\t"
-                           withString:@"\\t"
-                              options:NSCaseInsensitiveSearch
-                                range:NSMakeRange(0, [escaped length])];
-  return [NSString stringWithString:escaped];
-}
-
-
 @end

--- a/EarlGrey/Common/GREYConfiguration.m
+++ b/EarlGrey/Common/GREYConfiguration.m
@@ -60,8 +60,8 @@ NSString *const kGREYConfigKeyScreenshotDirLocation = @"GREYConfigKeyScreenshotD
     [self setDefaultValue:searchPaths.firstObject forConfigKey:kGREYConfigKeyScreenshotDirLocation];
     [self setDefaultValue:@YES forConfigKey:kGREYConfigKeyAnalyticsEnabled];
     [self setDefaultValue:@YES forConfigKey:kGREYConfigKeyActionConstraintsEnabled];
-    [self setDefaultValue:@(30.0) forConfigKey:kGREYConfigKeyInteractionTimeoutDuration];
-    [self setDefaultValue:@(10.0) forConfigKey:kGREYConfigKeyCALayerMaxAnimationDuration];
+    [self setDefaultValue:@(30) forConfigKey:kGREYConfigKeyInteractionTimeoutDuration];
+    [self setDefaultValue:@(10) forConfigKey:kGREYConfigKeyCALayerMaxAnimationDuration];
     [self setDefaultValue:@YES forConfigKey:kGREYConfigKeySynchronizationEnabled];
     [self setDefaultValue:@(1.5) forConfigKey:kGREYConfigKeyNSTimerMaxTrackableInterval];
     [self setDefaultValue:@YES forConfigKey:kGREYConfigKeyCALayerModifyAnimations];

--- a/EarlGrey/Common/GREYFailureFormatter.m
+++ b/EarlGrey/Common/GREYFailureFormatter.m
@@ -90,7 +90,6 @@
   }
 
   NSMutableArray *logger = [[NSMutableArray alloc] init];
-
   [logger addObject:[NSString stringWithFormat:@"%@: %@\n", failureLabel, failureName]];
 
   if (![excluding containsObject:kErrorFilePathKey]) {
@@ -135,18 +134,16 @@
 
   // UI hierarchy and legend. Print windows from front to back, formatted for easier readability.
   if (![excluding containsObject:kErrorAppUIHierarchyKey]) {
-
-    [logger addObject:@"\n\nUI hierarchy (ordered by window level, front to back as rendered):\n"];
+    [logger addObject:@"UI hierarchy (ordered by window level, front to back as rendered):\n"];
 
     NSDictionary *legendLabels = @{ @"[Window 1]" : @"Frontmost Window",
-                                    @"[AX]" : @"[Accessibility]",
-                                    @"[UIE]" : @"User Interaction Enabled]" };
+                                    @"[AX]" : @"Accessibility",
+                                    @"[UIE]" : @"User Interaction Enabled" };
     NSString *legendDescription = [GREYObjectFormatter formatDictionary:legendLabels
                                                                  indent:GREYObjectFormatIndent
                                                               hideEmpty:NO
                                                                keyOrder:nil];
     [logger addObject:[NSString stringWithFormat:@"%@: %@\n", @"Legend", legendDescription]];
-
     // Append the hierarchy for all UI Windows in the app.
     [logger addObject:error.appUIHierarchy];
   }

--- a/EarlGrey/Common/GREYObjectFormatter+Internal.h
+++ b/EarlGrey/Common/GREYObjectFormatter+Internal.h
@@ -23,16 +23,18 @@
 @interface GREYObjectFormatter (Internal)
 
 /**
- *  Serializes an array of objects into JSON string.
+ *  Serializes an array of objects into JSON-like string.
  *  The supported objects are: NSString, NSNumber, NSArray, NSDictionary.
+ *
+ *  @remark The serialized string is formatted as a JSON for presentation purposes but it doesn't
+ *          have the right escaping applied for special character as it hinders readability.
  *
  *  @param array    The array to serialize.
  *  @param prefix   A string that will be applied to each newline of the serialized array.
  *  @param indent   The spaces that will be applied to each element of the serialized array.
  *  @param keyOrder Output the key-value pair in the order of the keys specified
  *                  in the keyOrder array.
- *
- *  @return JSON-ified string of the provided @c array.
+ *  @return Serialized JSON-like string of the provided @c array.
  */
 + (NSString *)formatArray:(NSArray *)array
                    prefix:(NSString *)prefix
@@ -40,8 +42,11 @@
                  keyOrder:(NSArray *)keyOrder;
 
 /**
- *  Serializes a dictionary of objects into JSON string.
+ *  Serializes a dictionary of objects into JSON-like string.
  *  The supported objects are: NSString, NSNumber, NSArray, NSDictionary.
+ *
+ *  @remark The serialized string is formatted as a JSON for presentation purposes but it doesn't
+ *          have the right escaping applied for special character as it hinders readability.
  *
  *  @param dictionary The dictionary to serialize.
  *  @param prefix     A string that will be applied to each newline
@@ -53,7 +58,7 @@
  *  @param keyOrder   Output the key-value pair in the order of the keys specified
  *                    in the keyOrder array.
  *
- *  @return JSON-ified string of the provided @c dictionary.
+ *  @return Serialized string of the provided @c dictionary.
  */
 + (NSString *)formatDictionary:(NSDictionary *)dictionary
                         prefix:(NSString *)prefix

--- a/EarlGrey/Common/GREYObjectFormatter.m
+++ b/EarlGrey/Common/GREYObjectFormatter.m
@@ -145,8 +145,11 @@ NSInteger const GREYObjectFormatIndent = 2;
 #pragma mark - Private
 
 /**
- *  Serializes a object into JSON string.
+ *  Serializes a object into JSON-like string.
  *  The supported objects are: NSString, NSNumber, NSArray, NSDictionary.
+ *
+ *  @remark The serialized string is formatted as a JSON for presentation purposes but it doesn't
+ *          have the right escaping applied for special character as it hinders readability.
  *
  *  @param object        The object to serialize.
  *  @param prefixString  Whether a prefix string should be applied to each newline
@@ -156,7 +159,7 @@ NSInteger const GREYObjectFormatIndent = 2;
  *  @param indent        Number of spaces that will be applied to each element
  *                       of the serialized dictionary.
  *
- *  @return JSON-ified string of the provided @c object.
+ *  @return Serialized string of the provided @c object.
  */
 
 + (NSString *)grey_formatObject:(id)object
@@ -184,9 +187,9 @@ NSInteger const GREYObjectFormatIndent = 2;
       return [NSString stringWithFormat:@"%@%@\"%@\"",
                                         prefix,
                                         indentString,
-                                        [objectString grey_JSONEscape]];
+                                        objectString];
     } else {
-      return [NSString stringWithFormat:@"\"%@\"", [objectString grey_JSONEscape]];
+      return [NSString stringWithFormat:@"\"%@\"", objectString];
     }
   } else if ([object isKindOfClass:[NSNumber class]]) {
     return [object stringValue];
@@ -205,8 +208,7 @@ NSInteger const GREYObjectFormatIndent = 2;
                                         keyOrder:keyOrder];
   }
 
-  NSAssert(NO, @"output type");
-
+  NSAssert(NO, @"Unhandled output type: %@", [object class]);
   return nil;
 }
 

--- a/EarlGrey/Core/GREYElementInteraction.m
+++ b/EarlGrey/Core/GREYElementInteraction.m
@@ -583,9 +583,9 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
                                                                 indent:GREYObjectFormatIndent
                                                              hideEmpty:YES
                                                               keyOrder:keyOrder];
-        NSString *reason = [NSString stringWithFormat:@"Thread executor errors.\n"
-                                                      @"Exception with Action: %@\n",
-                                                      reasonDetail];
+        NSString *reason =
+            [NSString stringWithFormat:@"Timed out while waiting to perform action.\n"
+                                       @"Exception with Action: %@\n", reasonDetail];
 
         if ([actionError isKindOfClass:[GREYError class]]) {
           [(GREYError *)actionError setErrorInfo:errorDetails];
@@ -608,9 +608,8 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
 
           errorDetails[kErrorDetailActionNameKey] = action.name;
           errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
-          errorDetails[kErrorDetailRecoverySuggestionKey] = @"Check if element exists in the UI, "
-                                                            @"modify assert criteria, "
-                                                            @"or adjust element matcher";
+          errorDetails[kErrorDetailRecoverySuggestionKey] =
+              @"Check if element exists in the UI, modify assert criteria, or adjust the matcher";
 
           NSArray *keyOrder = @[ kErrorDetailActionNameKey,
                                  kErrorDetailElementMatcherKey,
@@ -619,7 +618,7 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
                                                                   indent:GREYObjectFormatIndent
                                                                hideEmpty:YES
                                                                 keyOrder:keyOrder];
-          NSString *reason = [NSString stringWithFormat:@"UI element cannot be found.\n"
+          NSString *reason = [NSString stringWithFormat:@"Cannot find UI element.\n"
                                                         @"Exception with Action: %@\n",
                                                         reasonDetail];
 
@@ -639,8 +638,8 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
 
           errorDetails[kErrorDetailActionNameKey] = action.name;
           errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
-          errorDetails[kErrorDetailRecoverySuggestionKey] = @"Create a more specific matcher "
-          @"to limit matched element";
+          errorDetails[kErrorDetailRecoverySuggestionKey] =
+              @"Create a more specific matcher to narrow matched element";
 
           NSArray *keyOrder = @[ kErrorDetailActionNameKey,
                                  kErrorDetailElementMatcherKey,
@@ -760,9 +759,9 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
                                                                 indent:GREYObjectFormatIndent
                                                              hideEmpty:YES
                                                               keyOrder:keyOrder];
-        NSString *reason = [NSString stringWithFormat:@"Thread executor errors."
-                                                      @"Exception with Assertion: %@\n",
-                                                      reasonDetail];
+        NSString *reason =
+            [NSString stringWithFormat:@"Timed out while waiting to perform assertion.\n"
+                                       @"Exception with Assertion: %@\n", reasonDetail];
 
         if ([assertionError isKindOfClass:[GREYError class]]) {
           [(GREYError *)assertionError setErrorInfo:errorDetails];
@@ -786,9 +785,8 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
 
           errorDetails[kErrorDetailAssertCriteriaKey] = assertion.name;
           errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
-          errorDetails[kErrorDetailRecoverySuggestionKey] = @"Check if element exists in the UI, "
-                                                            @"modify assert criteria, "
-                                                            @"or adjust element matcher";
+          errorDetails[kErrorDetailRecoverySuggestionKey] =
+              @"Check if element exists in the UI, modify assert criteria, or adjust the matcher";
 
           NSArray *keyOrder = @[ kErrorDetailAssertCriteriaKey,
                                  kErrorDetailElementMatcherKey,
@@ -797,7 +795,7 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
                                                                   indent:GREYObjectFormatIndent
                                                                hideEmpty:YES
                                                                 keyOrder:keyOrder];
-          NSString *reason = [NSString stringWithFormat:@"UI element cannot be found."
+          NSString *reason = [NSString stringWithFormat:@"Cannot find UI Element.\n"
                                                         @"Exception with Assertion: %@\n",
                                                         reasonDetail];
 
@@ -816,8 +814,8 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
 
           errorDetails[kErrorDetailAssertCriteriaKey] = assertion.name;
           errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
-          errorDetails[kErrorDetailRecoverySuggestionKey] = @"Create a more specific matcher to "
-                                                            @"limit matched element";
+          errorDetails[kErrorDetailRecoverySuggestionKey] =
+              @"Create a more specific matcher to narrow matched element";
 
           NSArray *keyOrder = @[ kErrorDetailAssertCriteriaKey,
                                  kErrorDetailElementMatcherKey,
@@ -926,7 +924,7 @@ NSString *const kErrorDetailElementMatcherKey = @"Element Matcher";
 - (NSString *)grey_searchActionDescription {
   if (_searchAction) {
     return [NSString stringWithFormat:@"Search action: %@. \nSearch action element matcher: %@.\n",
-            _searchAction, _searchActionElementMatcher];
+                                      _searchAction, _searchActionElementMatcher];
   } else {
     return @"";
   }

--- a/EarlGrey/Synchronization/GREYAppStateTracker.m
+++ b/EarlGrey/Synchronization/GREYAppStateTracker.m
@@ -197,8 +197,8 @@ static pthread_mutex_t gStateLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
   }
   if (state & kGREYPendingCAAnimation) {
     [eventStateString addObject:@"Waiting for CAAnimations to finish. Continuous animations may "
-                                @"never finish and must be stop explicitly. Animations attached to "
-                                @"hidden view may still be executing in the background."];
+                                @"never finish and must be stopped explicitly. Animations attached "
+                                @"to hidden view may still be running in the background."];
   }
   if (state & kGREYPendingRootViewControllerToAppear) {
     [eventStateString addObject:@"Waiting for window's rootViewController to appear. "

--- a/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.m
@@ -167,7 +167,7 @@ static NSString *const kFTRNetworkProxyErrorDomain =
 }
 
 /**
- * @remark This is a required overidden method.
+ *  @remark This is a required overidden method.
  *
  *  @return A canonical version of the specified @c request.
  */

--- a/Tests/UnitTests/Sources/GREYObjectFormatterTest.m
+++ b/Tests/UnitTests/Sources/GREYObjectFormatterTest.m
@@ -135,9 +135,7 @@
                                           indent:GREYObjectFormatIndent
                                         keyOrder:nil];
   } @catch (NSException *exception) {
-    NSString *reason = @"output type";
-    XCTAssertTrue([exception.reason isEqualToString:reason],
-                  @"Error getting unsupported error for dictionary formatting");
+    XCTAssertEqualObjects(exception.reason, @"Unhandled output type: NSObject");
   }
   XCTAssertNil(formatted,
                @"Error getting unsupported error for dictionary formatting");
@@ -194,9 +192,7 @@
                                             hideEmpty:NO
                                              keyOrder:nil];
   } @catch (NSException *exception) {
-    NSString *reason = @"output type";
-    XCTAssertTrue([exception.reason isEqualToString:reason],
-                  @"Error getting unsupported error for dictionary formatting");
+    XCTAssertEqualObjects(exception.reason, @"Unhandled output type: NSObject");
   }
   XCTAssertNil(formatted,
                @"Error getting unsupported error for dictionary formatting");

--- a/Tests/UnitTests/Sources/GREYUIThreadExecutorTest.m
+++ b/Tests/UnitTests/Sources/GREYUIThreadExecutorTest.m
@@ -163,7 +163,7 @@ static BOOL gAppStateTrackerIdle;
   XCTAssertEqualObjects(kGREYUIThreadExecutorErrorDomain, error.domain);
   XCTAssertEqual(kGREYUIThreadExecutorTimeoutErrorCode, error.code);
 
-  NSString *errorSubstring = @"'background thread'";
+  NSString *errorSubstring = @"background thread";
   BOOL errorMatched = [error.description rangeOfString:errorSubstring].length > 0;
   XCTAssertTrue(errorMatched,
                 @"Reason '%@' does not contain substring '%@'",
@@ -402,8 +402,12 @@ static BOOL gAppStateTrackerIdle;
                                                                           block:^{}
                                                                           error:&error];
   XCTAssertTrue(timeout);
-  XCTAssertGreaterThan([error.localizedDescription rangeOfString:@"Test Idling Resource"].length,
-                       0ul);
+  NSString *errorSubstring = @"Test Idling Resource";
+  BOOL errorMatched = [error.description rangeOfString:@"Test Idling Resource"].length > 0;
+  XCTAssertTrue(errorMatched,
+                @"Reason '%@' does not contain substring '%@'",
+                error.description,
+                errorSubstring);
 }
 
 @end


### PR DESCRIPTION
Github import of changes:

  - - Removing JSON escape in reported errors. It makes it confusing to understand the error by escaping string values.
- Presenting ThreadExecutor timeouts in a better format:

PiperOrigin-RevId: 145506353