### PR TITLE
Add NS_NON_NULL macro to surround all GREYMatchers. Without them, you…

### DIFF
--- a/EarlGrey/Matcher/GREYMatchers.h
+++ b/EarlGrey/Matcher/GREYMatchers.h
@@ -19,6 +19,8 @@
 #import <EarlGrey/GREYDefines.h>
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol GREYMatcher;
 
 /**
@@ -537,3 +539,5 @@ GREY_EXPORT id<GREYMatcher> grey_greaterThan(id value);
 GREY_EXPORT id<GREYMatcher> grey_scrolledToContentEdge(GREYContentEdge edge);
 
 #endif // GREY_DISABLE_SHORTHAND
+
+NS_ASSUME_NONNULL_END

--- a/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
+++ b/Tests/FunctionalTests/Sources/FTRSwiftTests.swift
@@ -94,9 +94,12 @@ class FTRSwiftTests: XCTestCase {
 
   func testTyping() {
     self.openTestView("Typing Views")
-    EarlGrey.select(elementWithMatcher: grey_accessibilityID("TypingTextField"))
-      .perform(grey_typeText("Sample Swift Test"))
-      .assert(grey_text("Sample Swift Test"))
+    let matcher = grey_accessibilityID("TypingTextField")
+    let action = grey_typeText("Sample Swift Test")
+    let assertionMatcher = grey_text("Sample Swift Test")
+    EarlGrey.select(elementWithMatcher: matcher)
+      .perform(action)
+      .assert(assertionMatcher)
   }
 
   func testTypingWithError() {

--- a/Tests/UnitTests/Sources/GREYAssertionsTest.m
+++ b/Tests/UnitTests/Sources/GREYAssertionsTest.m
@@ -37,11 +37,10 @@ static NSMutableArray *gAppWindows;
   [[[self.mockSharedApplication stub] andReturn:gAppWindows] windows];
 }
 
-- (void)testViewHasTextWithNilParameter {
+- (void)testViewHasTextWithEmptyString {
   UIView *view = [[UIView alloc] init];
   NSError *error;
-
-  [[GREYAssertions grey_createAssertionWithMatcher:grey_text(nil)] assert:view error:&error];
+  [[GREYAssertions grey_createAssertionWithMatcher:grey_text(@"")] assert:view error:&error];
   XCTAssertEqualObjects(error.domain, kGREYInteractionErrorDomain);
   XCTAssertEqual(error.code, kGREYInteractionAssertionFailedErrorCode);
 }


### PR DESCRIPTION
… are always provided a value that would have to be unwrapped / force wrapped that will throw a warning when directly captured in a variable. Modified a test that should throw up a warning if the nullability wasn't correct