### PR TITLE
Move kGREYFailureHandlerKey to Assertion Defines and remove its re-de…

### DIFF
--- a/EarlGrey/Assertion/GREYAssertionDefines.h
+++ b/EarlGrey/Assertion/GREYAssertionDefines.h
@@ -26,7 +26,7 @@
 #import <EarlGrey/GREYFailureHandler.h>
 #import <EarlGrey/GREYFrameworkException.h>
 
-GREY_EXTERN NSString *const kGREYFailureHandlerKey;
+GREY_EXPORT id<GREYFailureHandler> getFailureHandler();
 
 #pragma mark - Public
 
@@ -236,8 +236,7 @@ GREY_EXTERN NSString *const kGREYFailureHandlerKey;
 ({ \
   NSString *details__; \
   I_GREYFormattedString(details__, __details, ##__VA_ARGS__); \
-  id<GREYFailureHandler> failureHandler__ = \
-      [[[NSThread currentThread] threadDictionary] valueForKey:kGREYFailureHandlerKey]; \
+  id<GREYFailureHandler> failureHandler__ = getFailureHandler(); \
   [failureHandler__ handleException:[GREYFrameworkException exceptionWithName:__exceptionName \
                                                                        reason:(__description)] \
                             details:(details__)]; \
@@ -246,8 +245,7 @@ GREY_EXTERN NSString *const kGREYFailureHandlerKey;
 // No private macro should call this.
 #define I_GREYSetCurrentAsFailable() \
 ({ \
-  id<GREYFailureHandler> failureHandler__ = \
-      [[[NSThread currentThread] threadDictionary] valueForKey:kGREYFailureHandlerKey]; \
+  id<GREYFailureHandler> failureHandler__ = getFailureHandler(); \
   if ([failureHandler__ respondsToSelector:@selector(setInvocationFile:andInvocationLine:)]) { \
     [failureHandler__ setInvocationFile:[NSString stringWithUTF8String:__FILE__] \
                       andInvocationLine:__LINE__]; \

--- a/EarlGrey/Assertion/GREYAssertions.m
+++ b/EarlGrey/Assertion/GREYAssertions.m
@@ -34,8 +34,7 @@
 + (void)grey_raiseExceptionNamed:(NSString *)name
                 exceptionDetails:(NSString *)details
                        withError:(GREYError *)error {
-  id<GREYFailureHandler> failureHandler =
-  [[[NSThread currentThread] threadDictionary] valueForKey:kGREYFailureHandlerKey];
+  id<GREYFailureHandler> failureHandler = getFailureHandler();
   NSString *reason = [GREYError grey_nestedDescriptionForError:error];
   [failureHandler handleException:[GREYFrameworkException exceptionWithName:name
                                                                      reason:reason]

--- a/EarlGrey/EarlGrey.m
+++ b/EarlGrey/EarlGrey.m
@@ -91,8 +91,7 @@ static inline void resetFailureHandler() {
   [TLSDict setValue:[[GREYDefaultFailureHandler alloc] init] forKey:kGREYFailureHandlerKey];
 }
 
-// Returns the current failure handler. Not thread safe.
-static inline id<GREYFailureHandler> getFailureHandler() {
+inline id<GREYFailureHandler> getFailureHandler() {
   NSMutableDictionary *TLSDict = [[NSThread currentThread] threadDictionary];
   return [TLSDict valueForKey:kGREYFailureHandlerKey];
 }


### PR DESCRIPTION
…claration in EarlGrey.h. Having this multiple declaration throws a jazzy warning.