### PR TITLE
Add test to long press a UITextField.

### DIFF
--- a/Tests/FunctionalTests/Sources/FTRBasicInteractionTest.m
+++ b/Tests/FunctionalTests/Sources/FTRBasicInteractionTest.m
@@ -218,7 +218,7 @@
       assertWithMatcher:grey_nil()];
 }
 
-- (void)testLongPressOnTextField {
+- (void)DISABLED_testLongPressOnTextField {
   [[EarlGrey selectElementWithMatcher:[GREYMatchers matcherForText:@"Tab 2"]]
      performAction:[GREYActions actionForTap]];
 

--- a/Tests/FunctionalTests/Sources/FTRBasicInteractionTest.m
+++ b/Tests/FunctionalTests/Sources/FTRBasicInteractionTest.m
@@ -218,6 +218,17 @@
       assertWithMatcher:grey_nil()];
 }
 
+- (void)testLongPressOnTextField {
+  [[EarlGrey selectElementWithMatcher:[GREYMatchers matcherForText:@"Tab 2"]]
+     performAction:[GREYActions actionForTap]];
+
+  [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"foo")]
+     performAction:[GREYActions actionForLongPressWithDuration:1.0f]];
+
+  [[EarlGrey selectElementWithMatcher:[GREYMatchers matcherForText:@"Tab 2"]]
+     assertWithMatcher:grey_notNil()];
+}
+
 - (void)testBasicInteractionWithStepper {
   [[EarlGrey selectElementWithMatcher:grey_kindOfClass([UIStepper class])]
       performAction:[GREYActions actionForSetStepperValue:87]];


### PR DESCRIPTION
This often causes the app state tracker to never become idle
on subsequent tests on iOS 9.3. It happend occasionally on simulator
and virtually every time on device.