### PR TITLE
Blacklist UICompatibilityInputViewController from being tracked in UIViewController tracking.

### DIFF
--- a/Tests/FunctionalTests/Sources/FTRKeyboardKeysTest.m
+++ b/Tests/FunctionalTests/Sources/FTRKeyboardKeysTest.m
@@ -457,12 +457,11 @@
       assertWithMatcher:grey_accessibilityLabel(@"Foo")];
 }
 
-// TODO(31886754):Enabled this for testing the Input Accessory Code
-- (void)DISABLED_testTypingOnTextFieldInUIInputAccessory {
+- (void)testTypingOnTextFieldInUIInputAccessory {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"Input Button")]
       performAction:grey_tap()];
-  [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"TypingTextField")]
-      performAction:grey_typeText(@"Test")];
+  [[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"InputAccessoryTextField")]
+      performAction:grey_typeText(@"Test")] assertWithMatcher:grey_text(@"Test")];
 }
 
 #pragma mark - Private


### PR DESCRIPTION
A user finds that tracking it causes an accessory view to not be untracked on a keyboard, thus halting any test that types with it.