### PR TITLE
Enable accessibility on device on iOS 9.1 +

### DIFF
--- a/EarlGrey/Core/GREYAutomationSetup.m
+++ b/EarlGrey/Core/GREYAutomationSetup.m
@@ -202,7 +202,9 @@ static GREYSignalHandler gPreviousSignalHandlers[kNumSignals];
   reset = [swizzler resetInstanceMethod:@selector(addObserverForName:object:queue:usingBlock:)
                                   class:[NSNotificationCenter class]];
   NSAssert(reset, @"Failed to reset swizzled method addObserverForName:object:queue:usingBlock:");
-  if (iOS10_OR_ABOVE()) {
+  // The method may not be available on older versions of XCTest/Xcode
+  // This is needed on iOS 9.1 and higher
+  if ([XCAXClient respondsToSelector:@selector(loadAccessibility:)]) {
     void *unused = 0;
     [XCAXClient loadAccessibility:&unused];
   }


### PR DESCRIPTION
On iOS 9.1 and higher, -[XCAXClient_iOS loadAccessibility:] is needed, but it is
not available on older versions of XCTest/Xcode, replacing with
-[respondToSelector:] check.