### PR TITLE
Re-organizing Example project install instructions

### DIFF
--- a/Demo/EarlGreyExample/README.md
+++ b/Demo/EarlGreyExample/README.md
@@ -7,7 +7,9 @@ An example that shows several features of EarlGrey.
 `EarlGreyExampleTests` and `EarlGreyExampleSwiftTests` are test targets that exercise
 different functionalities provide by EarlGrey, written in Objective-C and Swift.
 
-## Getting Started - CocoaPods
+## Getting Started
+
+### CocoaPods
 
 Execute `gem install earlgrey` then `pod install` from the directory where you have downloaded
 the source of the example, then `open EarlGreyExample.xcworkspace` to open the example in xcode.
@@ -17,7 +19,7 @@ running `gem install cocoapods`.
 
 Run the tests that you want to see in action.
 
-## Getting Started - Carthage
+### Carthage
 
 From the directory containing the example source, run:
 


### PR DESCRIPTION
Putting them under Getting starting with each install method as its own section header.