### PR TITLE
Fixing a bug in interaction point calculation.

### DIFF
--- a/EarlGrey/Additions/UIViewController+GREYAdditions.m
+++ b/EarlGrey/Additions/UIViewController+GREYAdditions.m
@@ -27,7 +27,7 @@
  *  The class for UICompatibilityInputViewController which isn't tracked here since we've faced
  *  issues with tracking it when it comes to typing on keyboards with accessory views.
  */
-static Class compatibilityVCClass;
+static Class gCompatibilityVCClass;
 
 @implementation UIViewController (GREYAdditions)
 
@@ -72,7 +72,7 @@ static Class compatibilityVCClass;
 
 + (void)initialize {
   if (self == [UIViewController class]) {
-    compatibilityVCClass = NSClassFromString(@"UICompatibilityInputViewController");
+    gCompatibilityVCClass = NSClassFromString(@"UICompatibilityInputViewController");
   }
 }
 
@@ -122,7 +122,7 @@ static Class compatibilityVCClass;
 - (void)greyswizzled_viewWillAppear:(BOOL)animated {
   // For a UICompatibilityInputViewController, do not track this state due to issues seen with
   // untracking.
-  if (![self isKindOfClass:compatibilityVCClass]) {
+  if (![self isKindOfClass:gCompatibilityVCClass]) {
     BOOL movingToNilWindow = [self grey_isMovingToNilWindow];
     if (movingToNilWindow) {
       GREYLogVerbose(@"View is moving to nil window. Skipping viewWillAppear state tracking.");

--- a/EarlGrey/Common/GREYVisibilityChecker.h
+++ b/EarlGrey/Common/GREYVisibilityChecker.h
@@ -58,7 +58,7 @@ void GREYVisibilityDiffBufferRelease(GREYVisibilityDiffBuffer buffer);
  *  @param x      The x coordinate of the search point.
  *  @param y      The y coordinate of the search point.
  */
-BOOL GREYVisibilityDiffBufferIsVisibleAt(GREYVisibilityDiffBuffer buffer, size_t x, size_t y);
+BOOL GREYVisibilityDiffBufferIsVisible(GREYVisibilityDiffBuffer buffer, size_t x, size_t y);
 
 /**
  *  Changes the visibility value for the {@c x, @c y} position. If @c isVisible is @c YES the point
@@ -70,12 +70,25 @@ BOOL GREYVisibilityDiffBufferIsVisibleAt(GREYVisibilityDiffBuffer buffer, size_t
  *  @param isVisible A boolean that indicates the new visibility status (@c YES for visible,
                      @c NO otherwise) for the target point.
  */
-void GREYVisibilityDiffBufferSetVisibilityAt(GREYVisibilityDiffBuffer buffer,
-                                             size_t x,
-                                             size_t y,
-                                             BOOL isVisible);
+void GREYVisibilityDiffBufferSetVisibility(GREYVisibilityDiffBuffer buffer,
+                                           size_t x,
+                                           size_t y,
+                                           BOOL isVisible);
 
 #pragma mark - GREYVisibilityChecker
+
+/**
+ *  Data structure to hold information about visible pixels.
+ */
+typedef struct GREYVisiblePixelData {
+  /** The number of visible pixels. */
+  NSUInteger visiblePixelCount;
+  /**
+   *  A default pixel that's visible.
+   *  If no pixel is visible -- i.e. the visiblePixelCount = 0, then this is set to CGPointNull.
+   */
+  CGPoint visiblePixel;
+} GREYVisiblePixelData;
 
 /**
  *  Checker for assessing the visibility of elements on screen as they appear to the user.
@@ -102,6 +115,7 @@ void GREYVisibilityDiffBufferSetVisibilityAt(GREYVisibilityDiffBuffer buffer,
 /**
  *  @return A visible point where a user can tap to interact with specified @c element, or
  *          @c GREYCGPointNull if there's no such point.
+ *  @remark The returned point is relative to @c element's bound.
  */
 + (CGPoint)visibleInteractionPointForElement:(id)element;
 

--- a/Tests/FunctionalTests/Sources/FTRAlertViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRAlertViewTest.m
@@ -43,6 +43,8 @@
       performAction:[GREYActions actionForTap]];
   [[EarlGrey selectElementWithMatcher:grey_text(@"Roger")]
       performAction:[GREYActions actionForTap]];
+  [[EarlGrey selectElementWithMatcher:grey_text(@"Multi-Option Alert")]
+      assertWithMatcher:grey_sufficientlyVisible()];
 }
 
 - (void)testAlertViewChain {
@@ -52,6 +54,8 @@
       performAction:[GREYActions actionForTap]];
   [[EarlGrey selectElementWithMatcher:grey_text(@"Roger")]
       performAction:[GREYActions actionForTap]];
+  [[EarlGrey selectElementWithMatcher:grey_text(@"Multi-Option Alert")]
+      assertWithMatcher:grey_sufficientlyVisible()];
 }
 
 - (void)testStyledAlertView {

--- a/Tests/FunctionalTests/Sources/FTRBasicInteractionTest.m
+++ b/Tests/FunctionalTests/Sources/FTRBasicInteractionTest.m
@@ -234,10 +234,10 @@
       performAction:[GREYActions actionForTap]];
 
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"foo")]
-      performAction:[GREYActions actionForTypeText:@"CopiedText"]];
+      performAction:[GREYActions actionForTypeText:@"Hello"]];
 
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"foo")]
-      performAction:[GREYActions actionForLongPressWithDuration:1.0f]];
+      performAction:[GREYActions actionForLongPressAtPoint:CGPointMake(1, 1) duration:1.0]];
 
   [[EarlGrey selectElementWithMatcher:grey_text(@"Select")]
       performAction:[GREYActions actionForTap]];
@@ -246,15 +246,15 @@
       performAction:[GREYActions actionForTap]];
 
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"foo")]
-      performAction:[GREYActions actionForTypeText:@"TextToCopyTo"]];
+      performAction:[GREYActions actionForTypeText:@"FromEarlGrey"]];
 
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"foo")]
-      performAction:[GREYActions actionForLongPressWithDuration:1.0f]];
+      performAction:[GREYActions actionForLongPressAtPoint:CGPointMake(1, 1) duration:1.0]];
 
   [[EarlGrey selectElementWithMatcher:grey_text(@"Paste")]
       performAction:[GREYActions actionForTap]];
 
-  [[EarlGrey selectElementWithMatcher:grey_text(@"TextToCopyToCopiedText")]
+  [[EarlGrey selectElementWithMatcher:grey_text(@"HelloFromEarlGrey")]
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 

--- a/Tests/FunctionalTests/TestRig/Sources/FTRVisibilityTestViewController.xib
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRVisibilityTestViewController.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FTRVisibilityTestViewController">
@@ -19,12 +23,12 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clipsSubviews="YES" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q5H-yC-ga6">
                     <rect key="frame" x="110" y="221" width="100" height="100"/>
-                    <color key="backgroundColor" red="1" green="0.072869415899999998" blue="0.096727123969999995" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="1" green="0.072869415899999998" blue="0.096727123969999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <accessibility key="accessibilityConfiguration" label="FTRRedSquare">
                         <bool key="isElement" value="YES"/>
                     </accessibility>
@@ -35,8 +39,8 @@
                 </view>
                 <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CXV-Sj-2gg">
                     <rect key="frame" x="90" y="241" width="70" height="100"/>
-                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="100" id="QJO-pd-wIN"/>
                         <constraint firstAttribute="width" constant="70" id="nOG-3B-jwK"/>
@@ -44,8 +48,8 @@
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZeP-zU-0iT">
                     <rect key="frame" x="90" y="211" width="120" height="60"/>
-                    <color key="backgroundColor" red="0.21034668079999999" green="0.20737630339999999" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                    <color key="tintColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.21034668079999999" green="0.20737630339999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="120" id="44w-rH-7pu"/>
                         <constraint firstAttribute="height" constant="60" id="Y4H-GX-6WA"/>
@@ -54,34 +58,34 @@
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FPB-QG-iMG">
                     <rect key="frame" x="75" y="171" width="152" height="30"/>
                     <state key="normal" title="Tap to obscure button">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" alpha="0.25000000000000006" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Translucent" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="335-Qa-d1H">
+                <label opaque="NO" userInteractionEnabled="NO" alpha="0.25000000000000006" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Translucent" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="335-Qa-d1H">
                     <rect key="frame" x="90" y="120" width="120" height="21"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="21" id="3YL-xm-luN"/>
                         <constraint firstAttribute="width" constant="120" id="uBt-BM-Cf2"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <view alpha="0.10000000000000001" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="02j-Xh-8Gl">
+                <view alpha="0.10000000000000001" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="02j-Xh-8Gl">
                     <rect key="frame" x="179" y="106" width="50" height="50"/>
-                    <color key="backgroundColor" red="0.10417509178555395" green="0.0" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.10417509178555395" green="0.0" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="b2C-62-Io8"/>
                         <constraint firstAttribute="width" constant="50" id="ipO-C6-eGz"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xEx-rc-Plt">
-                    <rect key="frame" x="76" y="411" width="100" height="2"/>
-                    <color key="backgroundColor" red="1" green="0.072869415899999998" blue="0.096727123969999995" alpha="1" colorSpace="calibratedRGB"/>
+                    <rect key="frame" x="110" y="411" width="20" height="2"/>
+                    <color key="backgroundColor" red="1" green="0.072869415899999998" blue="0.096727123969999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="2" id="SBN-eR-XFv"/>
-                        <constraint firstAttribute="width" constant="100" id="eNv-6F-5kj"/>
+                        <constraint firstAttribute="width" constant="20" id="eNv-6F-5kj"/>
                     </constraints>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="FTRRedBar"/>
@@ -99,49 +103,49 @@
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show activation point" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Fx-LV-Sky">
                     <rect key="frame" x="107" y="365" width="164" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vNo-Uc-0uo">
-                    <rect key="frame" x="115" y="402" width="20" height="20"/>
-                    <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <rect key="frame" x="110" y="402" width="20" height="20"/>
+                    <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="MUB-TT-wpt"/>
                         <constraint firstAttribute="width" constant="20" id="Ue3-GC-N4B"/>
                     </constraints>
                 </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PVN-Dk-eoX">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PVN-Dk-eoX">
                     <rect key="frame" x="76" y="50" width="37" height="21"/>
                     <accessibility key="accessibilityConfiguration" identifier="AView1" label="AView"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="37" id="Oih-rJ-ooS"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Bd-fu-NwU">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Bd-fu-NwU">
                     <rect key="frame" x="192" y="50" width="37" height="21"/>
                     <accessibility key="accessibilityConfiguration" identifier="AView3" label="AView"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="37" id="fAf-D0-l8r"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fhy-dK-rrT">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="View" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fhy-dK-rrT">
                     <rect key="frame" x="132" y="50" width="37" height="21"/>
                     <accessibility key="accessibilityConfiguration" identifier="AView2" label="AView"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="37" id="aGG-fS-l7P"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="7Bd-fu-NwU" firstAttribute="leading" secondItem="PVN-Dk-eoX" secondAttribute="trailing" constant="79" id="0HH-Kl-lnG"/>
                 <constraint firstItem="q5H-yC-ga6" firstAttribute="leading" secondItem="CXV-Sj-2gg" secondAttribute="trailing" constant="-50" id="1lP-Wb-T1Q"/>
@@ -155,12 +159,12 @@
                 <constraint firstItem="6Fx-LV-Sky" firstAttribute="leading" secondItem="EQL-Yp-Olh" secondAttribute="trailing" constant="10" id="GxT-2u-y3V"/>
                 <constraint firstItem="EQL-Yp-Olh" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="48" id="JIR-lN-ePE"/>
                 <constraint firstItem="FPB-QG-iMG" firstAttribute="top" secondItem="CXV-Sj-2gg" secondAttribute="bottom" constant="77" id="M5x-pb-EdF"/>
-                <constraint firstItem="vNo-Uc-0uo" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="115" id="QBc-ob-7eo"/>
+                <constraint firstItem="vNo-Uc-0uo" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="110" id="QBc-ob-7eo"/>
                 <constraint firstItem="q5H-yC-ga6" firstAttribute="top" secondItem="ZeP-zU-0iT" secondAttribute="bottom" constant="-50" id="XLU-44-TKa"/>
                 <constraint firstItem="02j-Xh-8Gl" firstAttribute="centerY" secondItem="335-Qa-d1H" secondAttribute="centerY" constant="0.5" id="Yc8-T2-ccY"/>
                 <constraint firstAttribute="trailing" secondItem="ZeP-zU-0iT" secondAttribute="trailing" constant="110" id="a1L-lQ-Dh1"/>
                 <constraint firstAttribute="trailing" secondItem="CXV-Sj-2gg" secondAttribute="trailing" constant="170" id="aQl-f0-GCh"/>
-                <constraint firstItem="xEx-rc-Plt" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="76" id="bqZ-Cx-jIp"/>
+                <constraint firstItem="xEx-rc-Plt" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="110" id="bqZ-Cx-jIp"/>
                 <constraint firstItem="ZeP-zU-0iT" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="90" id="cP5-NY-dTR"/>
                 <constraint firstItem="6Fx-LV-Sky" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="365" id="dRp-LY-gih"/>
                 <constraint firstAttribute="trailing" secondItem="q5H-yC-ga6" secondAttribute="trailing" constant="120" id="dzt-Hv-j4b"/>
@@ -179,7 +183,6 @@
                 <constraint firstItem="7Bd-fu-NwU" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" constant="50.5" id="xyK-Dh-XjD"/>
                 <constraint firstItem="7Bd-fu-NwU" firstAttribute="baseline" secondItem="PVN-Dk-eoX" secondAttribute="baseline" id="zvG-s9-uAp"/>
             </constraints>
-            <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
             <variation key="default">
                 <mask key="constraints">
                     <exclude reference="55f-Vv-nze"/>

--- a/Tests/UnitTests/Sources/GREYExposedForTesting.h
+++ b/Tests/UnitTests/Sources/GREYExposedForTesting.h
@@ -63,10 +63,10 @@ extern const NSInteger kGREYScrollDetectionLength;
 @end
 
 @interface GREYVisibilityChecker (GREYExposedForTesting)
-+ (NSUInteger)grey_countPixelsInImage:(CGImageRef)afterImage
-           thatAreShiftedPixelsOfImage:(CGImageRef)beforeImage
-           storeVisiblePixelRectInRect:(CGRect *)outVisiblePixelRect
-      andStoreComparisonResultInBuffer:(GREYVisibilityDiffBuffer *)outDiffBufferOrNULL;
++ (GREYVisiblePixelData)grey_countPixelsInImage:(CGImageRef)afterImage
+                    thatAreShiftedPixelsOfImage:(CGImageRef)beforeImage
+                    storeVisiblePixelRectInRect:(CGRect *)outVisiblePixelRect
+               andStoreComparisonResultInBuffer:(GREYVisibilityDiffBuffer *)outDiffBufferOrNULL;
 @end
 
 @interface GREYElementHierarchy (GREYExposedForTesting)


### PR DESCRIPTION
Fix bug in visibility checker around interaction point. It is possible that neither the activation point nor the center of an element's visible area is actually visible even though, some part of the element is visible and interact-able by the user. To fix that, we use a default point guaranteed to be visible. The default point is selected from a set of visible point returned by performing pixel shift check.