### PR TITLE
Minor formatting fixes to failure messages.

### DIFF
--- a/EarlGrey/Action/GREYBaseAction.m
+++ b/EarlGrey/Action/GREYBaseAction.m
@@ -70,8 +70,8 @@
         *errorOrNil = error;
       } else {
         NSArray *keyOrder = @[ kErrorDetailActionNameKey,
-                               kErrorDetailElementDescriptionKey,
                                kErrorDetailConstraintRequirementKey,
+                               kErrorDetailElementDescriptionKey,
                                kErrorDetailConstraintDetailsKey,
                                kErrorDetailRecoverySuggestionKey ];
 

--- a/EarlGrey/Assertion/GREYAssertions.m
+++ b/EarlGrey/Assertion/GREYAssertions.m
@@ -44,7 +44,7 @@
 + (id<GREYAssertion>)grey_createAssertionWithMatcher:(id<GREYMatcher>)matcher {
   NSParameterAssert(matcher);
 
-  NSString *assertionName = [NSString stringWithFormat:@"assertWithMatcher: %@", matcher];
+  NSString *assertionName = [NSString stringWithFormat:@"assertWithMatcher:%@", matcher];
   return [GREYAssertionBlock assertionWithName:assertionName
                        assertionBlockWithError:^BOOL (id element, NSError *__strong *errorOrNil) {
     GREYStringDescription *mismatch = [[GREYStringDescription alloc] init];

--- a/EarlGrey/Matcher/GREYNot.m
+++ b/EarlGrey/Matcher/GREYNot.m
@@ -36,7 +36,7 @@
 }
 
 - (void)describeTo:(id<GREYDescription>)description {
-  [[description appendText:@"!"] appendDescriptionOf:_matcher];
+  [[[description appendText:@"!("] appendDescriptionOf:_matcher] appendText:@")"];
 }
 
 @end


### PR DESCRIPTION
- Moving error description after requirement key
- removing space in the assertion matcher description `assertionWithMatcher:<description>`
- wrapping GREYNot matcher description in brackets
- Small style-fix in `trackEventWithTrackingID` method documentation.