### PR TITLE
Fix Swift breaks by correcting issue with Gem adding EarlGrey.swift irrespective of the type of the project.

### DIFF
--- a/Demo/EarlGreyExample/EarlGreyExample.xcodeproj/project.pbxproj
+++ b/Demo/EarlGreyExample/EarlGreyExample.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		2CB7315A1C29E8E600CF35C1 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5F9961071AE0CF4F0034F503 /* LaunchScreen.xib */; };
 		2CB7315B1C29E8F400CF35C1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5F5A53591ADE670C00F81DF0 /* Main.storyboard */; };
 		2CE7FA481C35AAB00079DE2F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE7FA471C35AAB00079DE2F /* ViewController.swift */; };
-		2CE7FA491C35AAB00079DE2F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE7FA471C35AAB00079DE2F /* ViewController.swift */; };
 		5F5A537E1ADE67D500F81DF0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5A537D1ADE67D500F81DF0 /* AppDelegate.swift */; };
 		5F99610B1AE0CF4F0034F503 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F9961061AE0CF4F0034F503 /* Images.xcassets */; };
 		5FDE055D1B0DAA090037B82F /* EarlGreyExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FDE055C1B0DAA090037B82F /* EarlGreyExampleTests.m */; };
@@ -296,7 +295,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2CE7FA491C35AAB00079DE2F /* ViewController.swift in Sources */,
 				5FDE055D1B0DAA090037B82F /* EarlGreyExampleTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -532,6 +530,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "EarlGreyExampleSwift-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/EarlGreyExampleSwift.app/EarlGreyExampleSwift";
 			};
 			name = Debug;
@@ -562,6 +561,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "EarlGreyExampleSwift-Swift.h";
+				SWIFT_VERSION = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/EarlGreyExampleSwift.app/EarlGreyExampleSwift";
 			};
 			name = Release;

--- a/Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGreyExampleSwiftTests.swift
+++ b/Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGreyExampleSwiftTests.swift
@@ -16,6 +16,7 @@
 
 import EarlGrey
 import XCTest
+
 @testable import EarlGreyExampleSwift
 
 class EarlGreyExampleSwiftTests: XCTestCase {
@@ -248,6 +249,6 @@ class SampleFailureHandler : NSObject, GREYFailureHandler {
    *  @param details   Extra information about the failure.
    */
   public func handle(_ exception: GREYFrameworkException!, details: String!) {
-    print("Test Failed With Reason : \(exception.reason) and details \(details)")
+    print("Test Failed With Reason : \(exception.reason!) and details \(details)")
   }
 }

--- a/Demo/EarlGreyExample/EarlGreyExampleTests/EarlGreyExampleTests.m
+++ b/Demo/EarlGreyExample/EarlGreyExampleTests/EarlGreyExampleTests.m
@@ -83,7 +83,8 @@
   // Second way to disambiguate: use inRoot to focus on a specific window or container.
   // There are two buttons with accessibility id "Send", but only one is inside SendMessageView.
   [[[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"Send")]
-      inRoot:grey_kindOfClass([SendMessageView class])] performAction:grey_doubleTap()];
+      inRoot:grey_kindOfClass([SendMessageView class])]
+      performAction:grey_doubleTap()];
 }
 
 // Define a custom matcher for table cells that contains a date for a Thursday.

--- a/gem/lib/earlgrey/configure_earlgrey.rb
+++ b/gem/lib/earlgrey/configure_earlgrey.rb
@@ -364,8 +364,7 @@ module EarlGrey
     # @param [Xcodeproj::Project] project
     # @param [PBXNativeTarget] target
     def copy_swift_files(project, target, swift_version = nil)
-      return unless has_swift?(target) || !swift_version.nil?
-
+      return unless has_swift?(target) || !swift_version.to_s.empty?
       project_test_targets = project.main_group.children
       test_target_group = project_test_targets.find { |g| g.display_name == target.name }
 


### PR DESCRIPTION
Also deletes unneeded Swift App imports in the project which was causing the ObjC tests to also contain EarlGrey.swift.