### PR TITLE
EarlGrey is for white-box testing

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,8 +2,8 @@
 
 #### **How does EarlGrey compare to Xcode’s UI Testing?**
 
-EarlGrey is more of a [gray-box testing](https://en.wikipedia.org/wiki/Gray_box_testing) solution
-whereas Xcode’s UI Testing is completely [black-box](https://en.wikipedia.org/wiki/Black-box_testing).
+EarlGrey is a [white-box testing](https://en.wikipedia.org/wiki/White_box_testing) solution
+whereas Xcode’s UI Testing is [black-box](https://en.wikipedia.org/wiki/Black-box_testing).
 EarlGrey runs in the same process as the app under test, so it has access to the same memory as the
 app. This allows for better synchronization, such as ability to wait for network requests, and
 allows for custom synchronization mechanisms that aren’t possible when using Xcode’s UI Testing feature.


### PR DESCRIPTION
Clarifying that EarlGrey is more suited for white-box testing.