### PR TITLE
Bumping the amount of scroll value in testTableCellOutOfScreen

### DIFF
--- a/Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGreyExampleSwiftTests.swift
+++ b/Demo/EarlGreyExample/EarlGreyExampleSwiftTests/EarlGreyExampleSwiftTests.swift
@@ -109,7 +109,7 @@ class EarlGreyExampleSwiftTests: XCTestCase {
   func testTableCellOutOfScreen() {
     // Go find one cell out of the screen.
     EarlGrey.select(elementWithMatcher: grey_accessibilityID("Cell30"))
-      .usingSearch(grey_scrollInDirection(GREYDirection.down, 50),
+      .usingSearch(grey_scrollInDirection(GREYDirection.down, 100),
           onElementWith: grey_accessibilityID("table"))
       .perform(grey_tap())
     // Move back to top of the table.


### PR DESCRIPTION
due to the recent changes in scroll which made it more accurate but also slower, some tests that scroll little by little might time out occasionally if the search action that's using scroll takes longer than 30 seconds to find the element. There's only one such failure on travis with `testTableCellOutOfScreen` thus far.