### PR TITLE
Fix typo in the sample code to match the API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -268,7 +268,7 @@ of a block. The following code creates an action using a block that invokes a cu
 ```objc
 - (id<GREYAction>)animateWindowAction {
   return [GREYActionBlock actionWithName:@"Animate Window"
-                              constraint:nil
+                              constraints:nil
                             performBlock:^(id element, NSError *__strong *errorOrNil) {
     // First, make sure the element is attached to a window.
     if ([element window] == nil) {


### PR DESCRIPTION
The method is defined here:
https://github.com/google/EarlGrey/blob/master/EarlGrey/Action/GREYActionBlock.h#L61