### PR TITLE
Create a separate target to generate the universal framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ matrix:
         - DESTINATION="OS=10.2,name=iPhone 7 Plus" SDK=iphonesimulator10.2 TYPE="UNIT"
     - env:
       - TYPE="RUBY"
+    - osx_image: xcode8.3
+      env:
+      - TYPE="PACKAGE"
 before_install:
   - |
       echo "Checking if a CI run is needed post commit: ${TRAVIS_COMMIT_RANGE}"

--- a/EarlGrey.xcodeproj/project.pbxproj
+++ b/EarlGrey.xcodeproj/project.pbxproj
@@ -1214,7 +1214,6 @@
 		C88F9A2D1F39A5E000704BFF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1222,7 +1221,6 @@
 		C88F9A2E1F39A5E000704BFF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -1231,7 +1229,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -1276,7 +1274,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = "";

--- a/EarlGrey.xcodeproj/project.pbxproj
+++ b/EarlGrey.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		C88F9A2C1F39A5E000704BFF /* Release */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = C88F9A2F1F39A5E000704BFF /* Build configuration list for PBXAggregateTarget "Release" */;
+			buildPhases = (
+				C88F9A321F39A5F100704BFF /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = Release;
+			productName = Release;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		3F5122141EE1D37E0000CC56 /* GREYTraversal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F51220E1EE1D37E0000CC56 /* GREYTraversal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F5122151EE1D37E0000CC56 /* GREYTraversal.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F51220F1EE1D37E0000CC56 /* GREYTraversal.m */; };
@@ -1051,11 +1065,25 @@
 			projectRoot = "";
 			targets = (
 				FD1000E81C5B466F00B2DB0A /* EarlGrey */,
+				C88F9A2C1F39A5E000704BFF /* Release */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		C88F9A321F39A5F100704BFF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash Scripts/build-release.sh\n";
+		};
 		FDC5EEA01CAEEFC2006C5174 /* Setup EarlGrey Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1183,10 +1211,27 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		C88F9A2D1F39A5E000704BFF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		C88F9A2E1F39A5E000704BFF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = EQHXZ8M8AV;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		FD1000FB1C5B466F00B2DB0A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -1211,7 +1256,6 @@
 					"-fobjc-arc",
 					"-fobjc-arc-exceptions",
 				);
-				OTHER_CODE_SIGN_FLAGS = "";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-framework",
@@ -1231,7 +1275,8 @@
 		FD1000FC1C5B466F00B2DB0A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = "";
@@ -1256,7 +1301,6 @@
 					"-fobjc-arc",
 					"-fobjc-arc-exceptions",
 				);
-				OTHER_CODE_SIGN_FLAGS = "";
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-framework",
@@ -1373,6 +1417,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		C88F9A2F1F39A5E000704BFF /* Build configuration list for PBXAggregateTarget "Release" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C88F9A2D1F39A5E000704BFF /* Debug */,
+				C88F9A2E1F39A5E000704BFF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FD1000FA1C5B466F00B2DB0A /* Build configuration list for PBXNativeTarget "EarlGrey" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Scripts/build-release.sh
+++ b/Scripts/build-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  Copyright 2016 Google Inc.
+#  Copyright 2017 Google Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -27,18 +27,19 @@
 mkdir -p "${OUTPUT_DIR}"
 
 xcrun xcodebuild build -project "${PROJECT_FILE_PATH}" -target "EarlGrey" \
-  -configuration $CONFIGURATION_NAME -sdk iphoneos CODE_SIGN_IDENTITY="" \
+  -configuration "${CONFIGURATION_NAME}" -sdk iphoneos CODE_SIGN_IDENTITY="" \
   CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO ONLY_ACTIVE_ARCH=NO \
-  CONFIGURATION_BUILD_DIR=$OUTPUT_DIR/iphoneos
+  CONFIGURATION_BUILD_DIR="${OUTPUT_DIR}/iphoneos"
 
 xcrun xcodebuild build \ -project "${PROJECT_FILE_PATH}" -target "EarlGrey" \
-  -configuration $CONFIGURATION_NAME -sdk iphonesimulator  \
-  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO \
-  ONLY_ACTIVE_ARCH=NO CONFIGURATION_BUILD_DIR=$OUTPUT_DIR/iphonesimulator
+  -configuration "${CONFIGURATION_NAME}" -sdk iphonesimulator CODE_SIGN_IDENTITY="" \
+  CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO ONLY_ACTIVE_ARCH=NO \
+  CONFIGURATION_BUILD_DIR="${OUTPUT_DIR}/iphonesimulator"
 
-cp -r ${OUTPUT_DIR}/iphoneos/EarlGrey.framework $OUTPUT_DIR
+# Use the framework built for device as the final product and lipo it later.
+cp -r "${OUTPUT_DIR}/iphoneos/EarlGrey.framework" "${OUTPUT_DIR}"
 
-xcrun lipo -create ${OUTPUT_DIR}/iphoneos/EarlGrey.framework/EarlGrey \
-  ${OUTPUT_DIR}/iphonesimulator/EarlGrey.framework/EarlGrey \
-  -output $OUTPUT_DIR/EarlGrey.framework/EarlGrey
+xcrun lipo -create "${OUTPUT_DIR}/iphoneos/EarlGrey.framework/EarlGrey" \
+  "${OUTPUT_DIR}/iphonesimulator/EarlGrey.framework/EarlGrey" \
+  -output "${OUTPUT_DIR}/EarlGrey.framework/EarlGrey"
 

--- a/Scripts/build-release.sh
+++ b/Scripts/build-release.sh
@@ -1,0 +1,23 @@
+: "${PROJECT_FILE_PATH:=$(dirname ${BASH_SOURCE[0]})/../EarlGrey.xcodeproj}"
+: "${BUILD_DIR:=build}"
+: "${CONFIGURATION_NAME:=Release}"
+: "${OUTPUT_DIR:=build}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+xcrun xcodebuild build \
+    -project "${PROJECT_FILE_PATH}" -target "EarlGrey" -configuration $CONFIGURATION_NAME \
+    -sdk iphoneos CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO \
+    ONLY_ACTIVE_ARCH=NO CONFIGURATION_BUILD_DIR=$OUTPUT_DIR/iphoneos
+
+xcrun xcodebuild build \
+    -project "${PROJECT_FILE_PATH}" -target "EarlGrey" -configuration $CONFIGURATION_NAME \
+    -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO \
+    ONLY_ACTIVE_ARCH=NO CONFIGURATION_BUILD_DIR=$OUTPUT_DIR/iphonesimulator
+
+cp -r ${OUTPUT_DIR}/iphoneos/EarlGrey.framework $OUTPUT_DIR
+
+xcrun lipo -create ${OUTPUT_DIR}/iphoneos/EarlGrey.framework/EarlGrey \
+    ${OUTPUT_DIR}/iphonesimulator/EarlGrey.framework/EarlGrey \
+    -output $OUTPUT_DIR/EarlGrey.framework/EarlGrey
+

--- a/Scripts/build-release.sh
+++ b/Scripts/build-release.sh
@@ -1,3 +1,24 @@
+#!/bin/bash
+#
+#  Copyright 2016 Google Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+#  Build EarlGrey.framework in two SDK's: iphoneos and iphonesimulator, and 
+#  lipo into one universal framework under the BUILD_DIR folder.
+#
+
 : "${PROJECT_FILE_PATH:=$(dirname ${BASH_SOURCE[0]})/../EarlGrey.xcodeproj}"
 : "${BUILD_DIR:=build}"
 : "${CONFIGURATION_NAME:=Release}"
@@ -5,19 +26,19 @@
 
 mkdir -p "${OUTPUT_DIR}"
 
-xcrun xcodebuild build \
-    -project "${PROJECT_FILE_PATH}" -target "EarlGrey" -configuration $CONFIGURATION_NAME \
-    -sdk iphoneos CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO \
-    ONLY_ACTIVE_ARCH=NO CONFIGURATION_BUILD_DIR=$OUTPUT_DIR/iphoneos
+xcrun xcodebuild build -project "${PROJECT_FILE_PATH}" -target "EarlGrey" \
+  -configuration $CONFIGURATION_NAME -sdk iphoneos CODE_SIGN_IDENTITY="" \
+  CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO ONLY_ACTIVE_ARCH=NO \
+  CONFIGURATION_BUILD_DIR=$OUTPUT_DIR/iphoneos
 
-xcrun xcodebuild build \
-    -project "${PROJECT_FILE_PATH}" -target "EarlGrey" -configuration $CONFIGURATION_NAME \
-    -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO \
-    ONLY_ACTIVE_ARCH=NO CONFIGURATION_BUILD_DIR=$OUTPUT_DIR/iphonesimulator
+xcrun xcodebuild build \ -project "${PROJECT_FILE_PATH}" -target "EarlGrey" \
+  -configuration $CONFIGURATION_NAME -sdk iphonesimulator  \
+  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ENTITLEMENTS_REQUIRED=NO \
+  ONLY_ACTIVE_ARCH=NO CONFIGURATION_BUILD_DIR=$OUTPUT_DIR/iphonesimulator
 
 cp -r ${OUTPUT_DIR}/iphoneos/EarlGrey.framework $OUTPUT_DIR
 
 xcrun lipo -create ${OUTPUT_DIR}/iphoneos/EarlGrey.framework/EarlGrey \
-    ${OUTPUT_DIR}/iphonesimulator/EarlGrey.framework/EarlGrey \
-    -output $OUTPUT_DIR/EarlGrey.framework/EarlGrey
+  ${OUTPUT_DIR}/iphonesimulator/EarlGrey.framework/EarlGrey \
+  -output $OUTPUT_DIR/EarlGrey.framework/EarlGrey
 

--- a/Scripts/package.sh
+++ b/Scripts/package.sh
@@ -1,3 +1,24 @@
+#!/bin/bash
+#
+#  Copyright 2016 Google Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+#  Build and archive EarlGrey.framework into EarlGrey.zip in the current running
+#  folder so it is ready to use for github release and cocoapods deployment.
+#
+
 SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
 CURRENT_DIR=$PWD
 : "${PROJECT_FILE_PATH:=${SOURCE_DIR}/../EarlGrey.xcodeproj}"
@@ -10,7 +31,8 @@ readonly PACKAGE_FILES="README.md CHANGELOG.md LICENSE"
 
 # Make a universal dynamic framework build.
 export OUTPUT_DIR=$OUTPUT_TMP_DIR/build
-(cd $SOURCE_DIR/.. && xcrun xcodebuild build -project "${PROJECT_FILE_PATH}" -target "Release")
+(cd $SOURCE_DIR/.. \
+  && xcrun xcodebuild build -project "${PROJECT_FILE_PATH}" -target "Release")
 
 # Copy files to the temp dir and zip.
 mkdir -p $OUTPUT_PACKAGE_DIR
@@ -19,7 +41,7 @@ mkdir -p $OUTPUT_PACKAGE_DIR
 # Symlink the framework so we don't need to copy.
 ln -s "$OUTPUT_DIR/EarlGrey.framework" $OUTPUT_PACKAGE_DIR/EarlGrey.framework
 
-(cd $OUTPUT_DIR/.. && \
-    zip -r -X "$CURRENT_DIR/${PACKAGE_NAME}.zip" "${PACKAGE_NAME}")
+(cd $OUTPUT_DIR/.. \
+  && zip -r -X "$CURRENT_DIR/${PACKAGE_NAME}.zip" "${PACKAGE_NAME}")
 
 rm -rf $OUTPUT_TMP_DIR

--- a/Scripts/package.sh
+++ b/Scripts/package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  Copyright 2016 Google Inc.
+#  Copyright 2017 Google Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -19,29 +19,30 @@
 #  folder so it is ready to use for github release and cocoapods deployment.
 #
 
-SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
-CURRENT_DIR=$PWD
+SOURCE_DIR="$(dirname ${BASH_SOURCE[0]})"
+CURRENT_DIR="${PWD}"
+
 : "${PROJECT_FILE_PATH:=${SOURCE_DIR}/../EarlGrey.xcodeproj}"
 : "${OUTPUT_DIR:=${SOURCE_DIR}/build}"
 
 readonly PACKAGE_NAME="EarlGrey"
 readonly OUTPUT_TMP_DIR=$(mktemp -d)
-readonly OUTPUT_PACKAGE_DIR=$OUTPUT_TMP_DIR/$PACKAGE_NAME
+readonly OUTPUT_PACKAGE_DIR="${OUTPUT_TMP_DIR}/${PACKAGE_NAME}"
 readonly PACKAGE_FILES="README.md CHANGELOG.md LICENSE"
 
 # Make a universal dynamic framework build.
-export OUTPUT_DIR=$OUTPUT_TMP_DIR/build
-(cd $SOURCE_DIR/.. \
+export OUTPUT_DIR="${OUTPUT_TMP_DIR}/build"
+(cd "${SOURCE_DIR}/.." \
   && xcrun xcodebuild build -project "${PROJECT_FILE_PATH}" -target "Release")
 
 # Copy files to the temp dir and zip.
-mkdir -p $OUTPUT_PACKAGE_DIR
-(cd $SOURCE_DIR/.. && cp $PACKAGE_FILES $OUTPUT_PACKAGE_DIR)
+mkdir -p "${OUTPUT_PACKAGE_DIR}"
+(cd "${SOURCE_DIR}/.." && cp "${PACKAGE_FILES}" "${OUTPUT_PACKAGE_DIR}")
 
 # Symlink the framework so we don't need to copy.
-ln -s "$OUTPUT_DIR/EarlGrey.framework" $OUTPUT_PACKAGE_DIR/EarlGrey.framework
+ln -s "${OUTPUT_DIR}/EarlGrey.framework" "${OUTPUT_PACKAGE_DIR}/EarlGrey.framework"
 
-(cd $OUTPUT_DIR/.. \
-  && zip -r -X "$CURRENT_DIR/${PACKAGE_NAME}.zip" "${PACKAGE_NAME}")
+(cd "${OUTPUT_DIR}/.." \
+  && zip -r -X "${CURRENT_DIR}/${PACKAGE_NAME}.zip" "${PACKAGE_NAME}")
 
-rm -rf $OUTPUT_TMP_DIR
+rm -rf "${OUTPUT_TMP_DIR}"

--- a/Scripts/package.sh
+++ b/Scripts/package.sh
@@ -1,0 +1,25 @@
+SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
+CURRENT_DIR=$PWD
+: "${PROJECT_FILE_PATH:=${SOURCE_DIR}/../EarlGrey.xcodeproj}"
+: "${OUTPUT_DIR:=${SOURCE_DIR}/build}"
+
+readonly PACKAGE_NAME="EarlGrey"
+readonly OUTPUT_TMP_DIR=$(mktemp -d)
+readonly OUTPUT_PACKAGE_DIR=$OUTPUT_TMP_DIR/$PACKAGE_NAME
+readonly PACKAGE_FILES="README.md CHANGELOG.md LICENSE"
+
+# Make a universal dynamic framework build.
+export OUTPUT_DIR=$OUTPUT_TMP_DIR/build
+(cd $SOURCE_DIR/.. && xcrun xcodebuild build -project "${PROJECT_FILE_PATH}" -target "Release")
+
+# Copy files to the temp dir and zip.
+mkdir -p $OUTPUT_PACKAGE_DIR
+(cd $SOURCE_DIR/.. && cp $PACKAGE_FILES $OUTPUT_PACKAGE_DIR)
+
+# Symlink the framework so we don't need to copy.
+ln -s "$OUTPUT_DIR/EarlGrey.framework" $OUTPUT_PACKAGE_DIR/EarlGrey.framework
+
+(cd $OUTPUT_DIR/.. && \
+    zip -r -X "$CURRENT_DIR/${PACKAGE_NAME}.zip" "${PACKAGE_NAME}")
+
+rm -rf $OUTPUT_TMP_DIR

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -117,6 +117,8 @@ elif [ "${TYPE}" == "CARTHAGE" ]; then
   CONFIG="Release"
   ACTION="clean build"
   execute_xcodebuild EarlGrey.xcodeproj EarlGrey
+elif [ "${TYPE}" == "PACKAGE" ]; then
+  Scripts/package.sh
 else
   echo "Unrecognized Type: ${TYPE}"
   exit 1


### PR DESCRIPTION
If you check out the new run in travis here: https://travis-ci.org/google/EarlGrey/jobs/262478920, package.sh runs xcodebuild -target 'Release', which is a new target added here to build the dynamic framework in two SDKs - iphoneos and iphonesimulator - and lipo them to one. And then it archive it with README, CHANGELOG and LICENSE so it's ready for use.

build-release.sh is the script that builds both SDK and lipo.

package.sh will give you the final zip file under your current folder.