### PR TITLE
Correcting param name in documentation

### DIFF
--- a/EarlGrey/Action/GREYPinchAction.h
+++ b/EarlGrey/Action/GREYPinchAction.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Google Inc.
+// Copyright 2017 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-#import <EarlGrey/GREYBaseAction.h>
-#import <EarlGrey/GREYConstants.h>
+#import "googlemac/iPhone/Shared/Testing/EarlGrey/v2/AppFramework/Action/GREYBaseAction.h"
+#import "googlemac/iPhone/Shared/Testing/EarlGrey/v2/CommonLib/GREYConstants.h"
 
 /**
  *  Error domain used for pinch related NSError objects.
@@ -42,9 +42,9 @@ typedef NS_ENUM(NSInteger, GREYPinchErrorCode) {
  *  side and stops at the center. The default angle of the pinch action is 30 degrees to closely
  *  match the average pinch angle of a natural right handed pinch.
  *
- *  @param direction The direction of the pinch.
- *  @param duration  The time interval for which the pinch takes place.
- *  @param angle     Angle of the vector in radians to which the pinch direction is pointing.
+ *  @param direction  The direction of the pinch.
+ *  @param duration   The time interval for which the pinch takes place.
+ *  @param pinchAngle Angle of the vector in radians to which the pinch direction is pointing.
  *
  *  @returns An instance of @c GREYPinchAction, initialized with a provided direction and
  *           duration and angle.

--- a/EarlGrey/Action/GREYPinchAction.h
+++ b/EarlGrey/Action/GREYPinchAction.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2017 Google Inc.
+// Copyright 2016 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-#import "googlemac/iPhone/Shared/Testing/EarlGrey/v2/AppFramework/Action/GREYBaseAction.h"
-#import "googlemac/iPhone/Shared/Testing/EarlGrey/v2/CommonLib/GREYConstants.h"
+#import <EarlGrey/GREYBaseAction.h>
+#import <EarlGrey/GREYConstants.h>
 
 /**
  *  Error domain used for pinch related NSError objects.

--- a/EarlGrey/Additions/UIView+GREYAdditions.h
+++ b/EarlGrey/Additions/UIView+GREYAdditions.h
@@ -32,7 +32,7 @@
  *  Makes sure that subview @c view is always on top, even if other subviews are added in front of
  *  it. Also keeps the @c view's frame fixed to the current value so parent can't change it.
  *
- *  @param subview The view to keep as the top-most fixed subview.
+ *  @param view The view to keep as the top-most fixed subview.
  */
 - (void)grey_keepSubviewOnTopAndFrameFixed:(UIView *)view;
 

--- a/EarlGrey/Event/GREYTouchInfo.h
+++ b/EarlGrey/Event/GREYTouchInfo.h
@@ -54,8 +54,7 @@ typedef NS_ENUM(NSUInteger, GREYTouchInfoPhase) {
  *  Initializes this object to represent a touch at the the given @c points.
  *
  *  @param points                         The CGPoints where the touches are to be delivered.
- *  @param isLastTouch                    Specifies if this is a last touch object
- *                                        (that represents a 'touch-up')
+ *  @param phase                          The current phase of each touch point.
  *  @param timeDeltaSinceLastTouchSeconds The relative injection time from the time last
  *                                        touch point was injected. It is also used as the
  *                                        expected delivery time.


### PR DESCRIPTION
Get project ready for -Wdocumentation compiler flag by fixing all the incorrect parameters