### PR TITLE
Make EarlGrey and Functional tests work for deployment target <= 10.0.

### DIFF
--- a/EarlGrey/Additions/UIViewController+GREYAdditions.m
+++ b/EarlGrey/Additions/UIViewController+GREYAdditions.m
@@ -138,17 +138,18 @@ __attribute__((constructor)) static void initialize(void) {
       // Interactive transitions can cancel and cause imbalance of will and did calls.
       id<UIViewControllerTransitionCoordinator> coordinator = [self transitionCoordinator];
       if (coordinator && [coordinator initiallyInteractive]) {
-        id block = ^(id<UIViewControllerTransitionCoordinatorContext> context) {
-          if ([context isCancelled]) {
-            id object =
-                objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
-            UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToAppear, object);
-          }
-        };
-#if !defined(__IPHONE_10_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
-        [coordinator notifyWhenInteractionEndsUsingBlock:block];
+        void (^contextBlock)(id<UIViewControllerTransitionCoordinatorContext>) =
+            ^(id<UIViewControllerTransitionCoordinatorContext> context) {
+              if ([context isCancelled]) {
+                id object =
+                    objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
+                UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToAppear, object);
+              }
+            };
+#if !defined(__IPHONE_10_0) || (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)
+        [coordinator notifyWhenInteractionEndsUsingBlock:contextBlock];
 #else
-        [coordinator notifyWhenInteractionChangesUsingBlock:block];
+        [coordinator notifyWhenInteractionChangesUsingBlock:contextBlock];
 #endif
       }
 
@@ -183,17 +184,18 @@ __attribute__((constructor)) static void initialize(void) {
     // Interactive transitions can cancel and cause imbalance of will and did calls.
     id<UIViewControllerTransitionCoordinator> coordinator = [self transitionCoordinator];
     if (coordinator && [coordinator initiallyInteractive]) {
-      id block = ^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        if ([context isCancelled]) {
-          GREYAppStateTrackerObject *object =
-              objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
-          UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToDisappear, object);
-        }
-      };
-#if !defined(__IPHONE_10_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
-      [coordinator notifyWhenInteractionEndsUsingBlock:block];
+      void (^contextBlock)(id<UIViewControllerTransitionCoordinatorContext>) =
+          ^(id<UIViewControllerTransitionCoordinatorContext> context) {
+            if ([context isCancelled]) {
+              GREYAppStateTrackerObject *object =
+                  objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
+              UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToDisappear, object);
+            }
+          };
+#if !defined(__IPHONE_10_0) || (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)
+      [coordinator notifyWhenInteractionEndsUsingBlock:contextBlock];
 #else
-      [coordinator notifyWhenInteractionChangesUsingBlock:block];
+      [coordinator notifyWhenInteractionChangesUsingBlock:contextBlock];
 #endif
     }
 

--- a/EarlGrey/Additions/UIViewController+GREYAdditions.m
+++ b/EarlGrey/Additions/UIViewController+GREYAdditions.m
@@ -138,14 +138,18 @@ __attribute__((constructor)) static void initialize(void) {
       // Interactive transitions can cancel and cause imbalance of will and did calls.
       id<UIViewControllerTransitionCoordinator> coordinator = [self transitionCoordinator];
       if (coordinator && [coordinator initiallyInteractive]) {
-        [coordinator notifyWhenInteractionEndsUsingBlock:
-         ^(id<UIViewControllerTransitionCoordinatorContext> context) {
-           if ([context isCancelled]) {
-             id object =
-                 objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
-             UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToAppear, object);
-           }
-         }];
+        id block = ^(id<UIViewControllerTransitionCoordinatorContext> context) {
+          if ([context isCancelled]) {
+            id object =
+                objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
+            UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToAppear, object);
+          }
+        };
+#if !defined(__IPHONE_10_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
+        [coordinator notifyWhenInteractionEndsUsingBlock:block];
+#else
+        [coordinator notifyWhenInteractionChangesUsingBlock:block];
+#endif
       }
 
       GREYAppStateTrackerObject *object =
@@ -179,14 +183,18 @@ __attribute__((constructor)) static void initialize(void) {
     // Interactive transitions can cancel and cause imbalance of will and did calls.
     id<UIViewControllerTransitionCoordinator> coordinator = [self transitionCoordinator];
     if (coordinator && [coordinator initiallyInteractive]) {
-      [coordinator notifyWhenInteractionEndsUsingBlock:
-          ^(id<UIViewControllerTransitionCoordinatorContext> context) {
-            if ([context isCancelled]) {
-              GREYAppStateTrackerObject *object =
-                  objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
-              UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToDisappear, object);
-            }
-          }];
+      id block = ^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        if ([context isCancelled]) {
+          GREYAppStateTrackerObject *object =
+              objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
+          UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToDisappear, object);
+        }
+      };
+#if !defined(__IPHONE_10_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
+      [coordinator notifyWhenInteractionEndsUsingBlock:block];
+#else
+      [coordinator notifyWhenInteractionChangesUsingBlock:block];
+#endif
     }
 
     GREYAppStateTrackerObject *object =

--- a/EarlGrey/Synchronization/GREYDispatchQueueTracker.m
+++ b/EarlGrey/Synchronization/GREYDispatchQueueTracker.m
@@ -19,6 +19,7 @@
 #include <dlfcn.h>
 #include <fishhook.h>
 #include <libkern/OSAtomic.h>
+#include <stdatomic.h>
 
 #import "Common/GREYConfiguration.h"
 #import "Common/GREYFatalAsserts.h"
@@ -198,7 +199,7 @@ static void grey_dispatch_sync_f(dispatch_queue_t queue, void *context, dispatch
 
 @implementation GREYDispatchQueueTracker {
   __weak dispatch_queue_t _dispatchQueue;
-  __block int32_t _pendingBlocks;
+  __block atomic_int _pendingBlocks;
 }
 
 + (void)load {
@@ -271,7 +272,8 @@ static void grey_dispatch_sync_f(dispatch_queue_t queue, void *context, dispatch
 
 - (BOOL)isIdleNow {
   GREYFatalAssertWithMessage(_pendingBlocks >= 0, @"_pendingBlocks must not be negative");
-  BOOL isIdle = OSAtomicCompareAndSwap32Barrier(0, 0, &_pendingBlocks);
+  int expectedCount = 0;
+  BOOL isIdle = atomic_compare_exchange_strong(&_pendingBlocks, &expectedCount, 0);
   return isIdle;
 }
 
@@ -299,10 +301,10 @@ static void grey_dispatch_sync_f(dispatch_queue_t queue, void *context, dispatch
   dispatch_time_t trackDelay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(maxDelay * NSEC_PER_SEC));
 
   if (trackDelay >= when) {
-    OSAtomicIncrement32Barrier(&_pendingBlocks);
+    atomic_fetch_add(&_pendingBlocks, 1);
     grey_original_dispatch_after(when, _dispatchQueue, ^{
       block();
-      OSAtomicDecrement32Barrier(&_pendingBlocks);
+      atomic_fetch_sub(&_pendingBlocks, 1);
     });
   } else {
     grey_original_dispatch_after(when, _dispatchQueue, block);
@@ -310,18 +312,18 @@ static void grey_dispatch_sync_f(dispatch_queue_t queue, void *context, dispatch
 }
 
 - (void)grey_dispatchAsyncCallWithBlock:(dispatch_block_t)block {
-  OSAtomicIncrement32Barrier(&_pendingBlocks);
+  atomic_fetch_add(&_pendingBlocks, 1);
   grey_original_dispatch_async(_dispatchQueue, ^{
     block();
-    OSAtomicDecrement32Barrier(&_pendingBlocks);
+    atomic_fetch_sub(&_pendingBlocks, 1);
   });
 }
 
 - (void)grey_dispatchSyncCallWithBlock:(dispatch_block_t)block {
-  OSAtomicIncrement32Barrier(&_pendingBlocks);
+  atomic_fetch_add(&_pendingBlocks, 1);
   grey_original_dispatch_sync(_dispatchQueue, ^{
     block();
-    OSAtomicDecrement32Barrier(&_pendingBlocks);
+    atomic_fetch_sub(&_pendingBlocks, 1);
   });
 }
 
@@ -331,10 +333,10 @@ static void grey_dispatch_sync_f(dispatch_queue_t queue, void *context, dispatch
   CFTimeInterval maxDelay = GREY_CONFIG_DOUBLE(kGREYConfigKeyDispatchAfterMaxTrackableDelay);
   dispatch_time_t trackDelay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(maxDelay * NSEC_PER_SEC));
   if (trackDelay >= when) {
-    OSAtomicIncrement32Barrier(&_pendingBlocks);
+    atomic_fetch_add(&_pendingBlocks, 1);
     grey_original_dispatch_after(when, _dispatchQueue, ^{
       work(context);
-      OSAtomicDecrement32Barrier(&_pendingBlocks);
+      atomic_fetch_sub(&_pendingBlocks, 1);
     });
   } else {
     grey_original_dispatch_after_f(when, _dispatchQueue, context, work);
@@ -342,18 +344,18 @@ static void grey_dispatch_sync_f(dispatch_queue_t queue, void *context, dispatch
 }
 
 - (void)grey_dispatchAsyncCallWithContext:(void *)context work:(dispatch_function_t)work {
-  OSAtomicIncrement32Barrier(&_pendingBlocks);
+  atomic_fetch_add(&_pendingBlocks, 1);
   grey_original_dispatch_async(_dispatchQueue, ^{
     work(context);
-    OSAtomicDecrement32Barrier(&_pendingBlocks);
+    atomic_fetch_sub(&_pendingBlocks, 1);
   });
 }
 
 - (void)grey_dispatchSyncCallWithContext:(void *)context work:(dispatch_function_t)work {
-  OSAtomicIncrement32Barrier(&_pendingBlocks);
+  atomic_fetch_add(&_pendingBlocks, 1);
   grey_original_dispatch_sync(_dispatchQueue, ^{
     work(context);
-    OSAtomicDecrement32Barrier(&_pendingBlocks);
+    atomic_fetch_sub(&_pendingBlocks, 1);
   });
 }
 

--- a/Tests/FunctionalTests/Sources/FTRAlertViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRAlertViewTest.m
@@ -58,12 +58,10 @@
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
+// TODO: Fix this test when the deployment target is 9.0 or greater.
+// Link: https://github.com/google/EarlGrey/issues/645
+#if !defined(__IPHONE_9_0) || (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
 - (void)testStyledAlertView {
-  // TODO: Fix this test when the deployment target is 9.0 or greater.
-  // Link: https://github.com/google/EarlGrey/issues/645
-#if defined(__IPHONE_9_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0)
-  return;
-#endif
   [[EarlGrey selectElementWithMatcher:grey_text(@"Styled Alert")]
       performAction:[GREYActions actionForTap]];
 
@@ -78,5 +76,6 @@
   [[EarlGrey selectElementWithMatcher:grey_text(@"Leave")]
       performAction:[GREYActions actionForTap]];
 }
+#endif
 
 @end

--- a/Tests/FunctionalTests/Sources/FTRAlertViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRAlertViewTest.m
@@ -59,6 +59,11 @@
 }
 
 - (void)testStyledAlertView {
+  // TODO: Fix this test when the deployment target is 9.0 or greater.
+  // Link: https://github.com/google/EarlGrey/issues/645
+#if defined(__IPHONE_9_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0)
+  return;
+#endif
   [[EarlGrey selectElementWithMatcher:grey_text(@"Styled Alert")]
       performAction:[GREYActions actionForTap]];
 

--- a/Tests/FunctionalTests/Sources/FTRNetworkTest.m
+++ b/Tests/FunctionalTests/Sources/FTRNetworkTest.m
@@ -29,10 +29,6 @@
 }
 
 - (void)testSynchronizationWorksWithNSURLConnection {
-// This test uses APIs that don't exist when deployment target is 9.0 or greater.
-#if defined(__IPHONE_9_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0)
-  return;
-#endif
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"FTRRequestCompletedLabel")]
       assertWithMatcher:grey_notVisible()];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"NSURLConnectionTest")]

--- a/Tests/FunctionalTests/Sources/FTRNetworkTest.m
+++ b/Tests/FunctionalTests/Sources/FTRNetworkTest.m
@@ -29,6 +29,10 @@
 }
 
 - (void)testSynchronizationWorksWithNSURLConnection {
+// This test uses APIs that don't exist when deployment target is 9.0 or greater.
+#if defined(__IPHONE_9_0) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0)
+  return;
+#endif
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"FTRRequestCompletedLabel")]
       assertWithMatcher:grey_notVisible()];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"NSURLConnectionTest")]

--- a/Tests/FunctionalTests/TestRig/Sources/FTRNetworkTestViewController.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRNetworkTestViewController.m
@@ -68,13 +68,15 @@ static NSString *const kFTRProxyRegex = @"^http://www.youtube.com";
   }
 }
 
-#if !defined(__IPHONE_9_0) || (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
 - (IBAction)testNetworkClick:(id)sender {
+  // connectionWithRequest is deprecated on iOS 9 and higher.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSURLRequest *request =
       [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.youtube.com/"]];
   [NSURLConnection connectionWithRequest:request delegate:self];
+#pragma clang diagnostic pop
 }
-#endif
 
 - (IBAction)userDidTapNSURLSessionDelegateTest:(id)sender {
   NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];

--- a/Tests/FunctionalTests/TestRig/Sources/FTRNetworkTestViewController.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRNetworkTestViewController.m
@@ -68,11 +68,13 @@ static NSString *const kFTRProxyRegex = @"^http://www.youtube.com";
   }
 }
 
+#if !defined(__IPHONE_9_0) || (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
 - (IBAction)testNetworkClick:(id)sender {
   NSURLRequest *request =
       [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://www.youtube.com/"]];
   [NSURLConnection connectionWithRequest:request delegate:self];
 }
+#endif
 
 - (IBAction)userDidTapNSURLSessionDelegateTest:(id)sender {
   NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];


### PR DESCRIPTION
Remove use of APIS deprecated on iOS 10 deployment target:
Replace use of OSAtomic* APIs with methods from stdatomic.h.
Use notifyWhenInteractionChangesUsingBlock as a replacement for
notifyWhenInteractionEndsUsingBlock on iOS 10.0 and higher.

Disable tests that fail when deployment target is 9.0 or higher:
Disable failing tests that don't work when deployment target is 9.0 or
higher.
testSynchronizationWorksWithNSURLConnection relies upon a deprecated API,
so this test doesn't need to be run on iOS 9.0 or higher.
testStyledAlertView induces an alert on completion, which causes other tests
to fail, if the deployment target is 9.0 or higher.