### PR TITLE
Don't show keyboard tutorial for iPad

### DIFF
--- a/EarlGrey/Core/GREYAutomationSetup.m
+++ b/EarlGrey/Core/GREYAutomationSetup.m
@@ -248,6 +248,11 @@ static GREYSignalHandler gPreviousSignalHandlers[kNumSignals];
   } else {
     [controller setValue:@NO forPreferenceKey:@"KeyboardPrediction"];
   }
+
+  // To dismiss keyboard tutorial on iOS 11+. See https://github.com/google/EarlGrey/issues/633
+  if (iOS11_OR_ABOVE()) {
+    [controller setValue:@YES forPreferenceKey:@"DidShowGestureKeyboardIntroduction"];
+  }
   [controller synchronizePreferences];
 
   dlclose(handle);


### PR DESCRIPTION
Tell the preferences not to show keyboard tutorial as it interferes with typing.
Fixes #633