### PR TITLE
Add Support for Device Shake API

### DIFF
--- a/EarlGrey/Common/GREYAppleInternals.h
+++ b/EarlGrey/Common/GREYAppleInternals.h
@@ -146,6 +146,17 @@ IOHIDEventRef IOHIDEventCreateDigitizerFingerEvent(CFAllocatorRef allocator,
  *          UITouch objects, and the relevant touch interaction state.
  */
 - (UITouchesEvent *)_touchesEvent;
+
+/**
+ *  Sends a motion began event for the specified subtype.
+ */
+- (void) _sendMotionBegan:(UIEventSubtype)subtype;
+
+/**
+ *  Sends a motion ended event for the specified subtype.
+ */
+- (void) _sendMotionEnded:(UIEventSubtype)subtype;
+
 @end
 
 @interface UIScrollView (GREYExposed)

--- a/EarlGrey/Common/GREYAppleInternals.h
+++ b/EarlGrey/Common/GREYAppleInternals.h
@@ -125,6 +125,9 @@ IOHIDEventRef IOHIDEventCreateDigitizerFingerEvent(CFAllocatorRef allocator,
  */
 @interface BKSAccelerometer : NSObject
 
+/**
+ *  Enable or disable accelerometer events.
+ */
 @property (nonatomic) BOOL accelerometerEventsEnabled;
 
 @end

--- a/EarlGrey/Common/GREYAppleInternals.h
+++ b/EarlGrey/Common/GREYAppleInternals.h
@@ -133,11 +133,10 @@ IOHIDEventRef IOHIDEventCreateDigitizerFingerEvent(CFAllocatorRef allocator,
  *  A private class that represents motion related events. This is sent to UIApplication whenever a
  *  motion occurs.
  */
-@interface UIMotionEvent : NSObject
-{
+@interface UIMotionEvent : NSObject {
   /**
-  *  The motion accelerometer of the event.
-  */
+   *  The motion accelerometer of the event.
+   */
   BKSAccelerometer *_motionAccelerometer;
 }
 

--- a/EarlGrey/Common/GREYAppleInternals.h
+++ b/EarlGrey/Common/GREYAppleInternals.h
@@ -150,12 +150,12 @@ IOHIDEventRef IOHIDEventCreateDigitizerFingerEvent(CFAllocatorRef allocator,
 /**
  *  Sends a motion began event for the specified subtype.
  */
-- (void) _sendMotionBegan:(UIEventSubtype)subtype;
+- (void)_sendMotionBegan:(UIEventSubtype)subtype;
 
 /**
  *  Sends a motion ended event for the specified subtype.
  */
-- (void) _sendMotionEnded:(UIEventSubtype)subtype;
+- (void)_sendMotionEnded:(UIEventSubtype)subtype;
 
 @end
 

--- a/EarlGrey/Common/GREYAppleInternals.h
+++ b/EarlGrey/Common/GREYAppleInternals.h
@@ -120,6 +120,29 @@ IOHIDEventRef IOHIDEventCreateDigitizerFingerEvent(CFAllocatorRef allocator,
 - (void)_clearTouches;
 @end
 
+/**
+ *  A private class that represents backboard services accelerometer.
+ */
+@interface BKSAccelerometer : NSObject
+
+@property (nonatomic) BOOL accelerometerEventsEnabled;
+
+@end
+
+/**
+ *  A private class that represents motion related events. This is sent to UIApplication whenever a
+ *  motion occurs.
+ */
+@interface UIMotionEvent : NSObject
+{
+  /**
+  *  The motion accelerometer of the event.
+  */
+  BKSAccelerometer *_motionAccelerometer;
+}
+
+@end
+
 @interface UIApplication (GREYExposed)
 - (BOOL)_isSpringBoardShowingAnAlert;
 - (UIWindow *)statusBarWindow;
@@ -146,6 +169,11 @@ IOHIDEventRef IOHIDEventCreateDigitizerFingerEvent(CFAllocatorRef allocator,
  *          UITouch objects, and the relevant touch interaction state.
  */
 - (UITouchesEvent *)_touchesEvent;
+
+/**
+ *  @return The shared UIMotionEvent object of the application, used to force enable motion accelerometer events.
+ */
+- (UIMotionEvent *)_motionEvent;
 
 /**
  *  Sends a motion began event for the specified subtype.

--- a/EarlGrey/Core/EarlGreyImpl.h
+++ b/EarlGrey/Core/EarlGreyImpl.h
@@ -134,13 +134,27 @@ typedef NS_ENUM(NSInteger, GREYKeyboardDismissalErrorCode) {
  *  will be registered.
  *
  *  @param      deviceOrientation The desired orientation of the device.
- *  @param[out] errorOrNil        Error that will be populated on failure. If @c nil, a test
- *                                failure will be reported if the rotation attempt fails.
+ *  @param[out] errorOrNil Error that will be populated on failure. If @c nil, a test
+ *                         failure will be reported if the rotation attempt fails.
  *
  *  @return @c YES if the rotation was successful, @c NO otherwise.
  */
 - (BOOL)rotateDeviceToOrientation:(UIDeviceOrientation)deviceOrientation
                        errorOrNil:(__strong NSError **)errorOrNil;
+
+/**
+ *  Shakes the device. If a non-nil @c errorOrNil is provided, it will
+ *  be populated with the failure reason if the orientation change fails, otherwise a test failure
+ *  will be registered.
+ *
+ *  @param[out] errorOrNil Error that will be populated on failure. If @c nil, the a test
+ *                         failure will be reported if the shake attempt fails.
+ *
+ *  @throws GREYFrameworkException if the action fails and @c errorOrNil is @c nil.
+ *  @return @c YES if the shake was successful, @c NO otherwise. If @c errorOrNil is @c nil and
+ *          the operation fails, it will throw an exception.
+ */
+- (BOOL)shakeDeviceWithErrorOrNil:(__strong NSError **)errorOrNil;
 
 /**
  *  Dismisses the keyboard by resigning the first responder, if any. Will populate the provided
@@ -156,4 +170,3 @@ typedef NS_ENUM(NSInteger, GREYKeyboardDismissalErrorCode) {
 @end
 
 NS_ASSUME_NONNULL_END
-

--- a/EarlGrey/Core/EarlGreyImpl.h
+++ b/EarlGrey/Core/EarlGreyImpl.h
@@ -154,7 +154,7 @@ typedef NS_ENUM(NSInteger, GREYKeyboardDismissalErrorCode) {
  *  @return @c YES if the shake was successful, @c NO otherwise. If @c errorOrNil is @c nil and
  *          the operation fails, it will throw an exception.
  */
-- (BOOL)shakeDeviceWithErrorOrNil:(__strong NSError **)errorOrNil;
+- (BOOL)shakeDeviceWithError:(__strong NSError **)errorOrNil;
 
 /**
  *  Dismisses the keyboard by resigning the first responder, if any. Will populate the provided

--- a/EarlGrey/Core/EarlGreyImpl.m
+++ b/EarlGrey/Core/EarlGreyImpl.m
@@ -92,6 +92,10 @@ NSString *const kGREYKeyboardDismissalErrorDomain = @"com.google.earlgrey.Keyboa
   return [GREYSyntheticEvents rotateDeviceToOrientation:deviceOrientation errorOrNil:errorOrNil];
 }
 
+- (BOOL)shakeDeviceWithErrorOrNil:(__strong NSError **)errorOrNil {
+  return [GREYSyntheticEvents shakeDeviceWithErrorOrNil:errorOrNil];
+}
+
 - (BOOL)dismissKeyboardWithError:(__strong NSError **)errorOrNil {
   __block NSError *executionError;
   [[GREYUIThreadExecutor sharedInstance] executeSync:^{

--- a/EarlGrey/Core/EarlGreyImpl.m
+++ b/EarlGrey/Core/EarlGreyImpl.m
@@ -92,8 +92,8 @@ NSString *const kGREYKeyboardDismissalErrorDomain = @"com.google.earlgrey.Keyboa
   return [GREYSyntheticEvents rotateDeviceToOrientation:deviceOrientation errorOrNil:errorOrNil];
 }
 
-- (BOOL)shakeDeviceWithErrorOrNil:(__strong NSError **)errorOrNil {
-  return [GREYSyntheticEvents shakeDeviceWithErrorOrNil:errorOrNil];
+- (BOOL)shakeDeviceWithError:(__strong NSError **)errorOrNil {
+  return [GREYSyntheticEvents shakeDeviceWithError:errorOrNil];
 }
 
 - (BOOL)dismissKeyboardWithError:(__strong NSError **)errorOrNil {

--- a/EarlGrey/Event/GREYSyntheticEvents.h
+++ b/EarlGrey/Event/GREYSyntheticEvents.h
@@ -57,6 +57,20 @@ typedef NS_ENUM(NSInteger, GREYSyntheticEventInjectionErrorCode) {
                        errorOrNil:(__strong NSError **)errorOrNil;
 
 /**
+ *  Shakes the device. If a non-nil @c errorOrNil is provided, it will
+ *  be populated with the failure reason if the orientation change fails, otherwise a test failure
+ *  will be registered.
+ *
+ *  @param[out] errorOrNil        Error that will be populated on failure. If @c nil, the a test
+ *                                failure will be reported if the rotation attempt fails.
+ *
+ *  @throws GREYFrameworkException if the action fails and @c errorOrNil is @c nil.
+ *  @return @c YES if the shake was successful, @c NO otherwise. If @c errorOrNil is @c nil and
+ *          the operation fails, it will throw an exception.
+ */
++ (BOOL)shakeDeviceWithErrorOrNil:(__strong NSError **)errorOrNil;
+
+/**
  *  Touch along a specified path in a @c CGPoint array.
  *  This method blocks until all touches are delivered.
  *

--- a/EarlGrey/Event/GREYSyntheticEvents.h
+++ b/EarlGrey/Event/GREYSyntheticEvents.h
@@ -61,8 +61,8 @@ typedef NS_ENUM(NSInteger, GREYSyntheticEventInjectionErrorCode) {
  *  be populated with the failure reason if the orientation change fails, otherwise a test failure
  *  will be registered.
  *
- *  @param[out] errorOrNil        Error that will be populated on failure. If @c nil, the a test
- *                                failure will be reported if the shake attempt fails.
+ *  @param[out] errorOrNil Error that will be populated on failure. If @c nil, the a test
+ *                         failure will be reported if the shake attempt fails.
  *
  *  @throws GREYFrameworkException if the action fails and @c errorOrNil is @c nil.
  *  @return @c YES if the shake was successful, @c NO otherwise. If @c errorOrNil is @c nil and

--- a/EarlGrey/Event/GREYSyntheticEvents.h
+++ b/EarlGrey/Event/GREYSyntheticEvents.h
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSInteger, GREYSyntheticEventInjectionErrorCode) {
  *  @return @c YES if the shake was successful, @c NO otherwise. If @c errorOrNil is @c nil and
  *          the operation fails, it will throw an exception.
  */
-+ (BOOL)shakeDeviceWithErrorOrNil:(__strong NSError **)errorOrNil;
++ (BOOL)shakeDeviceWithError:(__strong NSError **)errorOrNil;
 
 /**
  *  Touch along a specified path in a @c CGPoint array.

--- a/EarlGrey/Event/GREYSyntheticEvents.h
+++ b/EarlGrey/Event/GREYSyntheticEvents.h
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, GREYSyntheticEventInjectionErrorCode) {
  *  will be registered.
  *
  *  @param[out] errorOrNil        Error that will be populated on failure. If @c nil, the a test
- *                                failure will be reported if the rotation attempt fails.
+ *                                failure will be reported if the shake attempt fails.
  *
  *  @throws GREYFrameworkException if the action fails and @c errorOrNil is @c nil.
  *  @return @c YES if the shake was successful, @c NO otherwise. If @c errorOrNil is @c nil and

--- a/EarlGrey/Event/GREYSyntheticEvents.m
+++ b/EarlGrey/Event/GREYSyntheticEvents.m
@@ -112,6 +112,29 @@ static const CFTimeInterval kRotationTimeout = 10.0;
   return YES;
 }
 
++ (BOOL)shakeDeviceWithErrorOrNil:(NSError *__strong *)errorOrNil {
+  GREYFatalAssertMainThread();
+  
+  NSError *error;
+  BOOL success = [[GREYUIThreadExecutor sharedInstance] executeSyncWithTimeout:kRotationTimeout
+                                                                         block:^{
+    //This behaves exactly in the same manner that UIApplication handles the simulator "Shake Gesture" menu command.
+    [[UIApplication sharedApplication] _sendMotionBegan:UIEventSubtypeMotionShake];
+    [[UIApplication sharedApplication] _sendMotionEnded:UIEventSubtypeMotionShake];
+  } error:&error];
+  
+  if (!success) {
+    if (errorOrNil) {
+      *errorOrNil = error;
+    } else {
+      I_GREYFail(@"Failed to shake device. Error: %@",
+                 [GREYError grey_nestedDescriptionForError:error]);
+    }
+    return NO;
+  }
+  return YES;
+}
+
 + (void)touchAlongPath:(NSArray *)touchPath
       relativeToWindow:(UIWindow *)window
            forDuration:(NSTimeInterval)duration

--- a/EarlGrey/Event/GREYSyntheticEvents.m
+++ b/EarlGrey/Event/GREYSyntheticEvents.m
@@ -112,7 +112,7 @@ static const CFTimeInterval kRotationTimeout = 10.0;
   return YES;
 }
 
-+ (BOOL)shakeDeviceWithErrorOrNil:(NSError *__strong *)errorOrNil {
++ (BOOL)shakeDeviceWithError:(NSError *__strong *)errorOrNil {
   GREYFatalAssertMainThread();
   
   NSError *error;

--- a/EarlGrey/Event/GREYSyntheticEvents.m
+++ b/EarlGrey/Event/GREYSyntheticEvents.m
@@ -119,11 +119,17 @@ static const CFTimeInterval kRotationTimeout = 10.0;
   NSError *error;
   BOOL success = [[GREYUIThreadExecutor sharedInstance] executeSyncWithTimeout:kRotationTimeout
                                                                          block:^{
-    //Keep previous accelerometer events enabled value and force it to YES so that the shake motion is passed to the application.
-    BOOL prevValue = [[[[UIApplication sharedApplication] _motionEvent] valueForKey:@"_motionAccelerometer"] accelerometerEventsEnabled];
-    [[[[UIApplication sharedApplication] _motionEvent] valueForKey:@"_motionAccelerometer"] setAccelerometerEventsEnabled:YES];
+    // Keep previous accelerometer events enabled value and force it to YES so that the shake
+    // motion is passed to the application.
+    UIApplication *application = [UIApplication sharedApplication];
+    BOOL prevValue =
+        [[[application _motionEvent] valueForKey:@"_motionAccelerometer"]
+            accelerometerEventsEnabled];
+    [[[[UIApplication sharedApplication] _motionEvent] valueForKey:@"_motionAccelerometer"]
+        setAccelerometerEventsEnabled:YES];
     
-    //This behaves exactly in the same manner that UIApplication handles the simulator "Shake Gesture" menu command.
+    // This behaves exactly in the same manner that UIApplication handles the simulator
+    // "Shake Gesture" menu command.
     [[UIApplication sharedApplication] _sendMotionBegan:UIEventSubtypeMotionShake];
     [[UIApplication sharedApplication] _sendMotionEnded:UIEventSubtypeMotionShake];
     

--- a/EarlGrey/Event/GREYSyntheticEvents.m
+++ b/EarlGrey/Event/GREYSyntheticEvents.m
@@ -27,6 +27,7 @@
 #import "Common/GREYThrowDefines.h"
 #import "Event/GREYTouchInjector.h"
 #import "Synchronization/GREYUIThreadExecutor.h"
+#import "Synchronization/GREYRunLoopSpinner.h"
 
 #pragma mark - Extern
 
@@ -118,9 +119,15 @@ static const CFTimeInterval kRotationTimeout = 10.0;
   NSError *error;
   BOOL success = [[GREYUIThreadExecutor sharedInstance] executeSyncWithTimeout:kRotationTimeout
                                                                          block:^{
+    //Keep previous accelerometer events enabled value and force it to YES so that the shake motion is passed to the application.
+    BOOL prevValue = [[[[UIApplication sharedApplication] _motionEvent] valueForKey:@"_motionAccelerometer"] accelerometerEventsEnabled];
+    [[[[UIApplication sharedApplication] _motionEvent] valueForKey:@"_motionAccelerometer"] setAccelerometerEventsEnabled:YES];
+    
     //This behaves exactly in the same manner that UIApplication handles the simulator "Shake Gesture" menu command.
     [[UIApplication sharedApplication] _sendMotionBegan:UIEventSubtypeMotionShake];
     [[UIApplication sharedApplication] _sendMotionEnded:UIEventSubtypeMotionShake];
+    
+    [[[[UIApplication sharedApplication] _motionEvent] valueForKey:@"_motionAccelerometer"] setAccelerometerEventsEnabled:prevValue];
   } error:&error];
   
   if (!success) {

--- a/EarlGrey/Event/GREYSyntheticEvents.m
+++ b/EarlGrey/Event/GREYSyntheticEvents.m
@@ -122,18 +122,16 @@ static const CFTimeInterval kRotationTimeout = 10.0;
     // Keep previous accelerometer events enabled value and force it to YES so that the shake
     // motion is passed to the application.
     UIApplication *application = [UIApplication sharedApplication];
-    BOOL prevValue =
-        [[[application _motionEvent] valueForKey:@"_motionAccelerometer"]
-            accelerometerEventsEnabled];
-    [[[[UIApplication sharedApplication] _motionEvent] valueForKey:@"_motionAccelerometer"]
-        setAccelerometerEventsEnabled:YES];
+    BKSAccelerometer *accelerometer = [[application _motionEvent] valueForKey:@"_motionAccelerometer"];
+    BOOL prevValue = accelerometer.accelerometerEventsEnabled;
+    accelerometer.accelerometerEventsEnabled = YES;
     
     // This behaves exactly in the same manner that UIApplication handles the simulator
     // "Shake Gesture" menu command.
-    [[UIApplication sharedApplication] _sendMotionBegan:UIEventSubtypeMotionShake];
-    [[UIApplication sharedApplication] _sendMotionEnded:UIEventSubtypeMotionShake];
+    [application _sendMotionBegan:UIEventSubtypeMotionShake];
+    [application _sendMotionEnded:UIEventSubtypeMotionShake];
     
-    [[[[UIApplication sharedApplication] _motionEvent] valueForKey:@"_motionAccelerometer"] setAccelerometerEventsEnabled:prevValue];
+    accelerometer.accelerometerEventsEnabled = prevValue;
   } error:&error];
   
   if (!success) {

--- a/Tests/FunctionalTests/FunctionalTests.xcodeproj/project.pbxproj
+++ b/Tests/FunctionalTests/FunctionalTests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		39175F1E2028CDC80096E2E1 /* FTRShakeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 39175F1D2028CDC80096E2E1 /* FTRShakeTest.m */; };
 		3FBDDF9A1F3D61870055E8F9 /* FTRLayoutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FBDDF981F3D61870055E8F9 /* FTRLayoutViewController.m */; };
 		3FBDDF9B1F3D61870055E8F9 /* FTRLayoutViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3FBDDF991F3D61870055E8F9 /* FTRLayoutViewController.xib */; };
 		59467DF91C9373A50089498B /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 59467D801C9373A50089498B /* LICENSE */; };
@@ -197,6 +198,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		39175F1D2028CDC80096E2E1 /* FTRShakeTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FTRShakeTest.m; sourceTree = "<group>"; };
 		3FBDDF971F3D61870055E8F9 /* FTRLayoutViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FTRLayoutViewController.h; sourceTree = "<group>"; };
 		3FBDDF981F3D61870055E8F9 /* FTRLayoutViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FTRLayoutViewController.m; sourceTree = "<group>"; };
 		3FBDDF991F3D61870055E8F9 /* FTRLayoutViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FTRLayoutViewController.xib; sourceTree = "<group>"; };
@@ -448,6 +450,7 @@
 				59467D7D1C9373A50089498B /* FTRUIWebViewTest.m */,
 				59467D7E1C9373A50089498B /* FTRVisibilityTest.m */,
 				D210ED931E72214A00978B9E /* FTRMultiFingerSwipeTest.m */,
+				39175F1D2028CDC80096E2E1 /* FTRShakeTest.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -868,6 +871,7 @@
 				59467E421C9373B90089498B /* FTRCollectionViewTest.m in Sources */,
 				59467E431C9373B90089498B /* FTRErrorAPITest.m in Sources */,
 				59467E451C9373B90089498B /* FTRFailureHandler.m in Sources */,
+				39175F1E2028CDC80096E2E1 /* FTRShakeTest.m in Sources */,
 				59467E461C9373B90089498B /* FTRGeometryTest.m in Sources */,
 				59467E471C9373B90089498B /* FTRGestureTest.m in Sources */,
 				59467E481C9373B90089498B /* FTRKeyboardKeysTest.m in Sources */,

--- a/Tests/FunctionalTests/Sources/FTRShakeTest.m
+++ b/Tests/FunctionalTests/Sources/FTRShakeTest.m
@@ -1,0 +1,29 @@
+//
+//  FTRShakeTest.m
+//  EarlGreyFunctionalTests
+//
+//  Created by Leo Natan (Wix) on 2/5/18.
+//  Copyright © 2018 Google Inc. All rights reserved.
+//
+
+#import "FTRBaseIntegrationTest.h"
+
+@interface FTRShakeTest : FTRBaseIntegrationTest
+
+@end
+
+@implementation FTRShakeTest
+
+- (void)setUp {
+	[super setUp];
+	[self openTestViewNamed:@"Rotated Views"];
+}
+
+- (void)testDeviceShake {
+	// Test rotating to landscape.
+	[EarlGrey shakeDeviceWithErrorOrNil:nil];
+	[[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"lastTapped")]
+	 assertWithMatcher:grey_text([NSString stringWithFormat:@"Device Was Shaken"])];
+}
+
+@end

--- a/Tests/FunctionalTests/Sources/FTRShakeTest.m
+++ b/Tests/FunctionalTests/Sources/FTRShakeTest.m
@@ -1,9 +1,17 @@
 //
-//  FTRShakeTest.m
-//  EarlGreyFunctionalTests
+// Copyright 2016 Google Inc.
 //
-//  Created by Leo Natan (Wix) on 2/5/18.
-//  Copyright © 2018 Google Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 #import "FTRBaseIntegrationTest.h"
@@ -15,15 +23,15 @@
 @implementation FTRShakeTest
 
 - (void)setUp {
-	[super setUp];
-	[self openTestViewNamed:@"Rotated Views"];
+  [super setUp];
+  [self openTestViewNamed:@"Rotated Views"];
 }
 
 - (void)testDeviceShake {
-	// Test rotating to landscape.
-	[EarlGrey shakeDeviceWithErrorOrNil:nil];
-	[[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"lastTapped")]
-	 assertWithMatcher:grey_text([NSString stringWithFormat:@"Device Was Shaken"])];
+  // Test rotating to landscape.
+  [EarlGrey shakeDeviceWithErrorOrNil:nil];
+  [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"lastTapped")]
+   assertWithMatcher:grey_text([NSString stringWithFormat:@"Device Was Shaken"])];
 }
 
 @end

--- a/Tests/FunctionalTests/Sources/FTRShakeTest.m
+++ b/Tests/FunctionalTests/Sources/FTRShakeTest.m
@@ -29,7 +29,7 @@
 
 - (void)testDeviceShake {
   // Test device shake.
-  [EarlGrey shakeDeviceWithErrorOrNil:nil];
+  [EarlGrey shakeDeviceWithError:nil];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"lastTapped")]
       assertWithMatcher:grey_text([NSString stringWithFormat:@"Device Was Shaken"])];
 }

--- a/Tests/FunctionalTests/Sources/FTRShakeTest.m
+++ b/Tests/FunctionalTests/Sources/FTRShakeTest.m
@@ -28,7 +28,7 @@
 }
 
 - (void)testDeviceShake {
-  // Test rotating to landscape.
+  // Test device shake.
   [EarlGrey shakeDeviceWithErrorOrNil:nil];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"lastTapped")]
    assertWithMatcher:grey_text([NSString stringWithFormat:@"Device Was Shaken"])];

--- a/Tests/FunctionalTests/Sources/FTRShakeTest.m
+++ b/Tests/FunctionalTests/Sources/FTRShakeTest.m
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
   // Test device shake.
   [EarlGrey shakeDeviceWithErrorOrNil:nil];
   [[EarlGrey selectElementWithMatcher:grey_accessibilityLabel(@"lastTapped")]
-   assertWithMatcher:grey_text([NSString stringWithFormat:@"Device Was Shaken"])];
+      assertWithMatcher:grey_text([NSString stringWithFormat:@"Device Was Shaken"])];
 }
 
 @end

--- a/Tests/FunctionalTests/TestRig/Sources/FTRRotatedViewsViewController.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRRotatedViewsViewController.m
@@ -22,10 +22,10 @@
 
 - (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent *)event
 {
-	if(event.subtype == UIEventSubtypeMotionShake)
-	{
-		[[self lastTappedLabel] setText:@"Device Was Shaken"];
-	}
+  if(event.subtype == UIEventSubtypeMotionShake)
+  {
+    [[self lastTappedLabel] setText:@"Device Was Shaken"];
+  }
 }
 
 - (IBAction)onTopLeftTapped:(id)sender {

--- a/Tests/FunctionalTests/TestRig/Sources/FTRRotatedViewsViewController.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRRotatedViewsViewController.m
@@ -20,6 +20,14 @@
 
 #pragma mark - Event handling
 
+- (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent *)event
+{
+	if(event.subtype == UIEventSubtypeMotionShake)
+	{
+		[[self lastTappedLabel] setText:@"Device Was Shaken"];
+	}
+}
+
 - (IBAction)onTopLeftTapped:(id)sender {
   [[self lastTappedLabel] setText:@"Last tapped: Top Left"];
 }

--- a/Tests/FunctionalTests/TestRig/Sources/FTRRotatedViewsViewController.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRRotatedViewsViewController.m
@@ -20,10 +20,8 @@
 
 #pragma mark - Event handling
 
-- (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent *)event
-{
-  if(event.subtype == UIEventSubtypeMotionShake)
-  {
+- (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent *)event {
+  if(event.subtype == UIEventSubtypeMotionShake) {
     [[self lastTappedLabel] setText:@"Device Was Shaken"];
   }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -616,3 +616,7 @@ You can choose from the following orientation modes (for more information, see [
   * `UIDeviceOrientationLandscapeRight`
   * `UIDeviceOrientationFaceUp`
   * `UIDeviceOrientationFaceDown`
+
+### Shake Gesture
+
+You can use `[EarlGrey shakeDeviceWithError:]` to simulate a shake gesture in a simulator.


### PR DESCRIPTION
Implements #678.
Added a functional test to test device shake.

Note that at the time of cloning the project, numerous unit tests are broken and do not pass on iOS 11.)