### PR TITLE
Strict function / block prototypes

### DIFF
--- a/EarlGrey/Assertion/GREYAssertionDefines.h
+++ b/EarlGrey/Assertion/GREYAssertionDefines.h
@@ -34,7 +34,7 @@
  *  Exposes internal method to get the failure handler registered with EarlGrey.
  *  It must be called from main thread otherwise the behavior is undefined.
  */
-GREY_EXPORT id<GREYFailureHandler> grey_getFailureHandler();
+GREY_EXPORT id<GREYFailureHandler> grey_getFailureHandler(void);
 
 /**
  *  These Macros are safe to call from anywhere within a testcase.

--- a/EarlGrey/Event/GREYZeroToleranceTimer.m
+++ b/EarlGrey/Event/GREYZeroToleranceTimer.m
@@ -71,7 +71,7 @@
  *  @return A dispatch_source_t pointing to the newly created timer.
  */
 + (dispatch_source_t)grey_scheduleZeroToleranceTimerWithInterval:(CFTimeInterval)interval
-                                                         handler:(void(^)())handler {
+                                                         handler:(void(^)(void))handler {
   dispatch_source_t timer =
       dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
   GREYFatalAssertWithMessage(timer, @"Timer could not be created");

--- a/EarlGrey/Synchronization/GREYAppStateTracker.m
+++ b/EarlGrey/Synchronization/GREYAppStateTracker.m
@@ -251,7 +251,7 @@ orInternalObjectDeallocationTracker:nil
   return [eventStateString componentsJoinedByString:@"\n"];
 }
 
-- (id)grey_performBlockInCriticalSection:(id (^)())block {
+- (id)grey_performBlockInCriticalSection:(id (^)(void))block {
   int lock = pthread_mutex_lock(&gStateLock);
   GREYFatalAssertWithMessage(lock == 0, @"Failed to lock.");
   id retVal = block();

--- a/EarlGrey/Synchronization/GREYRunLoopSpinner.m
+++ b/EarlGrey/Synchronization/GREYRunLoopSpinner.m
@@ -78,14 +78,14 @@ static void (^noopTimerHandler)(CFRunLoopTimerRef timer) = ^(CFRunLoopTimerRef t
   }
 
   __block NSUInteger drainCount = 0;
-  void (^drainCountingBlock)() = ^{
+  void (^drainCountingBlock)(void) = ^{
     drainCount++;
     if (drainCount >= exitDrainCount) {
       CFRunLoopStop(CFRunLoopGetCurrent());
     }
   };
 
-  void (^wakeUpBlock)() = ^{
+  void (^wakeUpBlock)(void) = ^{
     // Never let the run loop sleep while we are draining it for the minimum drains.
     CFRunLoopWakeUp(CFRunLoopGetCurrent());
   };
@@ -123,14 +123,14 @@ static void (^noopTimerHandler)(CFRunLoopTimerRef timer) = ^(CFRunLoopTimerRef t
  *  @return @c YES if the condition block was evaluated to YES while draining or after the active
  *          run loop finished; @c NO otherwise.
  */
-- (BOOL)grey_drainRunLoopInActiveModeAndCheckCondition:(BOOL (^)())stopConditionBlock
+- (BOOL)grey_drainRunLoopInActiveModeAndCheckCondition:(BOOL (^)(void))stopConditionBlock
                                                forTime:(CFTimeInterval)time {
   NSString *activeMode = [self grey_activeRunLoopMode];
   CFRunLoopTimerRef wakeUpTimer = [self grey_setupWakeUpTimerInMode:activeMode];
   __block BOOL conditionMet = NO;
   __weak __typeof__(self) weakSelf = self;
 
-  void (^beforeSourcesConditionCheckBlock)() = ^{
+  void (^beforeSourcesConditionCheckBlock)(void) = ^{
     __typeof__(self) strongSelf = weakSelf;
     GREYFatalAssertWithMessage(strongSelf, @"The spinner should not have been deallocated.");
 
@@ -143,7 +143,7 @@ static void (^noopTimerHandler)(CFRunLoopTimerRef timer) = ^(CFRunLoopTimerRef t
     }
   };
 
-  void (^beforeWaitingConditionCheckBlock)() = ^{
+  void (^beforeWaitingConditionCheckBlock)(void) = ^{
     __typeof__(self) strongSelf = weakSelf;
     GREYFatalAssertWithMessage(strongSelf, @"The spinner should not have been deallocated.");
 
@@ -197,7 +197,7 @@ static void (^noopTimerHandler)(CFRunLoopTimerRef timer) = ^(CFRunLoopTimerRef t
  *
  *  @return @c YES if the stop condition block evaluated to @YES; @c NO otherwise.
  */
-- (BOOL)grey_checkConditionInActiveMode:(BOOL (^)())stopConditionBlock  {
+- (BOOL)grey_checkConditionInActiveMode:(BOOL (^)(void))stopConditionBlock  {
   __block BOOL conditionMet = NO;
   __weak __typeof__(self) weakSelf = self;
 
@@ -238,8 +238,8 @@ static void (^noopTimerHandler)(CFRunLoopTimerRef timer) = ^(CFRunLoopTimerRef t
  *  @return The registered observer.
  */
 - (CFRunLoopObserverRef)grey_setupObserverInMode:(NSString *)mode
-                          withBeforeSourcesBlock:(void (^)())beforeSourcesBlock
-                              beforeWaitingBlock:(void (^)())beforeWaitingBlock {
+                          withBeforeSourcesBlock:(void (^)(void))beforeSourcesBlock
+                              beforeWaitingBlock:(void (^)(void))beforeWaitingBlock {
   __block int numNestedRunLoopModes = 0;
 
   void (^observerBlock)(CFRunLoopObserverRef observer, CFRunLoopActivity activity) =

--- a/EarlGrey/Synchronization/GREYSyncAPI.h
+++ b/EarlGrey/Synchronization/GREYSyncAPI.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param block Block that will be executed.
  */
-GREY_EXPORT void grey_execute_sync(void (^block)());
+GREY_EXPORT void grey_execute_sync(void (^block)(void));
 
 /**
  *  Executes a block containing EarlGrey statements on the main thread without waiting for it to
@@ -42,6 +42,6 @@ GREY_EXPORT void grey_execute_sync(void (^block)());
  *
  *  @param block Block that will be executed.
  */
-GREY_EXPORT void grey_execute_async(void (^block)());
+GREY_EXPORT void grey_execute_async(void (^block)(void));
 
 NS_ASSUME_NONNULL_END

--- a/EarlGrey/Synchronization/GREYSyncAPI.m
+++ b/EarlGrey/Synchronization/GREYSyncAPI.m
@@ -18,7 +18,7 @@
 
 #import "Assertion/GREYAssertionDefines.h"
 
-void grey_execute_sync(void (^block)()) {
+void grey_execute_sync(void (^block)(void)) {
   if ([NSThread isMainThread]) {
     NSLog(@"grey_execute_sync() cannot be invoked on the main thread. Aborting.");
     abort();
@@ -35,7 +35,7 @@ void grey_execute_sync(void (^block)()) {
   dispatch_semaphore_wait(waitForBlock, DISPATCH_TIME_FOREVER);
 }
 
-void grey_execute_async(void (^block)()) {
+void grey_execute_async(void (^block)(void)) {
   CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopDefaultMode, block);
   // CFRunLoopPerformBlock does not wake up the main queue.
   CFRunLoopWakeUp(CFRunLoopGetMain());


### PR DESCRIPTION
Use strict prototypes in function / block declarations.
(-Wstrict-prototypes)