### PR TITLE
Look for groups matching the test target name outside of the main group

### DIFF
--- a/gem/lib/earlgrey/configure_earlgrey.rb
+++ b/gem/lib/earlgrey/configure_earlgrey.rb
@@ -366,7 +366,7 @@ module EarlGrey
       project_test_targets = project.main_group.children
       test_target_group = recursively_find_group_with_name(project_test_targets, target.name)
 
-      raise "Test target group not found! #{test_target_group}" unless test_target_group
+      raise "Test target group not found! An Xcode group with the name #{target.name} should exist in your project" unless test_target_group
 
       swift_version ||= '3.0'
       src_root = File.join(__dir__, 'files')
@@ -411,7 +411,7 @@ module EarlGrey
       if target_group == nil
          groups.each do |group|
             if group.respond_to?(:children) && !group.children.nil?         
-             target_group = find_group_with_name(group.children, name)
+             target_group = recursively_find_group_with_name(group.children, name)
             end
             if !target_group.nil?
               break 

--- a/gem/lib/earlgrey/configure_earlgrey.rb
+++ b/gem/lib/earlgrey/configure_earlgrey.rb
@@ -366,7 +366,7 @@ module EarlGrey
       project_test_targets = project.main_group.children
       test_target_group = recursively_find_group_with_name(project_test_targets, target.name)
 
-      raise "Test target group not found! An Xcode group with the name #{target.name} should exist in your project" unless test_target_group
+      raise "Test target group not found! An Xcode group with the name '#{target.name}' should exist in your project" unless test_target_group
 
       swift_version ||= '3.0'
       src_root = File.join(__dir__, 'files')
@@ -406,14 +406,19 @@ module EarlGrey
       end
     end
 
+    # Recursively iterate through the group tree. Will return the first group with a matching name
+    #
+    # @param [Array<PBXGroup>] Array of groups
+    # @param [String] the group name to look for
     def recursively_find_group_with_name(groups, name)
       target_group = groups.find { |g| g.display_name == name }
-      if target_group == nil
+      if target_group.nil?
          groups.each do |group|
             if group.respond_to?(:children) && !group.children.nil?         
-             target_group = recursively_find_group_with_name(group.children, name)
+              target_group = recursively_find_group_with_name(group.children, name)
             end
             if !target_group.nil?
+              # Exit early if a group with a matching name has been found
               break 
             end
          end

--- a/gem/lib/earlgrey/configure_earlgrey.rb
+++ b/gem/lib/earlgrey/configure_earlgrey.rb
@@ -364,7 +364,7 @@ module EarlGrey
     def copy_swift_files(project, target, swift_version = nil)
       return unless has_swift?(target) || !swift_version.to_s.empty?
       project_test_targets = project.main_group.children
-      test_target_group = project_test_targets.find { |g| g.display_name == target.name }
+      test_target_group = recursively_find_group_with_name(project_test_targets, target.name)
 
       raise "Test target group not found! #{test_target_group}" unless test_target_group
 
@@ -404,6 +404,21 @@ module EarlGrey
         raise 'EarlGrey.swift not found in testing target' unless earlgrey_swift_file_ref
         target.source_build_phase.add_file_reference earlgrey_swift_file_ref, true
       end
+    end
+
+    def recursively_find_group_with_name(groups, name)
+      target_group = groups.find { |g| g.display_name == name }
+      if target_group == nil
+         groups.each do |group|
+            if group.respond_to?(:children) && !group.children.nil?         
+             target_group = find_group_with_name(group.children, name)
+            end
+            if !target_group.nil?
+              break 
+            end
+         end
+      end
+      return target_group
     end
   end
 end


### PR DESCRIPTION
In our project we have an intricate group structure and at some point the group containing our specs moved into a subfolder in the hierarchy. 

When we run pod install after adding EarlGrey it will fail with the error

```
RuntimeError - Test target group not found!
/Users/kasper/.rvm/gems/ruby-2.3.1/bundler/gems/EarlGrey-35532c4e95c6/gem/lib/earlgrey/configure_earlgrey.rb:369:in `copy_swift_files'
etc.
```

After looking through the code the culprit seemed to be the way the target names and group names are mathed inside configure_earlgrey.rb in copy_swift_files. In ```test_target_group = project_test_targets.find { |g| g.display_name == target.name }``` only the root groups are looked at, and it did not work for our project.

To solve the problem we have added a new method which will recurse through the group hierarchy until it finds a matching group name.