### PR TITLE
Add Fixes for Accessibility and Visibility Checker for iOS 12 / Xcode 10 Support.

### DIFF
--- a/EarlGrey/Common/GREYAppleInternals.h
+++ b/EarlGrey/Common/GREYAppleInternals.h
@@ -409,7 +409,7 @@ IOHIDEventRef IOHIDEventCreateDigitizerFingerEvent(CFAllocatorRef allocator,
  *
  *  @return ignored.
  */
-- (bool)loadAccessibility:(void **)unused;
+- (bool)_loadAccessibility:(void **)unused;
 
 @end
 

--- a/EarlGrey/Core/GREYAutomationSetup.m
+++ b/EarlGrey/Core/GREYAutomationSetup.m
@@ -217,9 +217,9 @@ static GREYSignalHandler gPreviousSignalHandlers[kNumSignals];
                              @"addObserverForName:object:queue:usingBlock:");
   // The method may not be available on older versions of XCTest/Xcode
   // This is needed on iOS 9.1 and higher
-  if ([XCAXClient respondsToSelector:@selector(loadAccessibility:)]) {
+  if ([XCAXClient respondsToSelector:@selector(_loadAccessibility:)]) {
     void *unused = 0;
-    [XCAXClient loadAccessibility:&unused];
+    [XCAXClient _loadAccessibility:&unused];
   }
 }
 


### PR DESCRIPTION
The Visibility Checker fix will also be in 2.0. Since we don't need Accessibility there, it will not be added in.