### PR TITLE
Update docs to fix func name

### DIFF
--- a/docs/install-and-run.md
+++ b/docs/install-and-run.md
@@ -268,7 +268,7 @@ compatible with EarlGrey.
       For Swift Tests:
 
       ```swift
-      func testExample() {
+      func testPresenceOfKeyWindow() {
         EarlGrey.selectElement(with: grey_keyWindow())
           .assert(grey_sufficientlyVisible())
       }


### PR DESCRIPTION
function name in the install and run document was changed from `testExample` to `testPresenceOfKeyWindow`.