### PR TITLE
Add dimissKeyboard to Swift interface

### DIFF
--- a/gem/lib/earlgrey/files/Swift-4.0/EarlGrey.swift
+++ b/gem/lib/earlgrey/files/Swift-4.0/EarlGrey.swift
@@ -138,6 +138,14 @@ open class EarlGrey: NSObject {
         .rotateDevice(to: orientation,
                       errorOrNil: errorOrNil)
   }
+  
+  @discardableResult open class func dismissKeyboard(errorOrNil: UnsafeMutablePointer<NSError?>!,
+                                                    file: StaticString = #file,
+                                                    line: UInt = #line)
+    -> Bool {
+      return EarlGreyImpl.invoked(fromFile: file.description, lineNumber: line)
+        .dismissKeyboardWithError(errorOrNil)
+  }
 }
 
 extension GREYInteraction {


### PR DESCRIPTION
Adds a missing implementation in Swift for `dismissKeyboard`.