### PR TITLE
Adds untracking for state kGREYPendingViewsToDisappear in greyswizzled_viewDidAppear

### DIFF
--- a/EarlGrey/Additions/UIViewController+GREYAdditions.m
+++ b/EarlGrey/Additions/UIViewController+GREYAdditions.m
@@ -166,7 +166,7 @@ __attribute__((constructor)) static void initialize(void) {
 - (void)greyswizzled_viewDidAppear:(BOOL)animated {
   GREYAppStateTrackerObject *object =
       objc_getAssociatedObject(self, @selector(greyswizzled_viewWillAppear:));
-  GREYAppState state = kGREYPendingViewsToAppear | kGREYPendingRootViewControllerToAppear;
+  GREYAppState state = kGREYPendingViewsToAppear | kGREYPendingRootViewControllerToAppear | kGREYPendingViewsToDisappear;
   UNTRACK_STATE_FOR_OBJECT(state, object);
 
   [self grey_setAppeared:YES];


### PR DESCRIPTION
Adds untracking for state kGREYPendingViewsToDisappear if a UIViewController's viewDidAppear has been called.

This is neccessary if the user triggers an incomplete transition between UIViewControllers e.g. in the context of a UIPageViewController. See this example for an explanation:

We show a UIPageViewController with three UIViewControllers <VC1>, <VC2>, and <VC3>.
This is the series of events:

* <VC1>.viewWillAppear
* <VC1>.viewDidAppear
* <VC1>.view is shown to the user
* User performs swipe left
* <VC2>.viewWillAppear
* <VC1>.viewWillDisappear
* <VC2>.viewDidAppear
* <VC1>.viewDidDisappear
* <VC2>.view is shown to the user
* User performs swipe left (This swipe does not go far enough to show <VC3>.view at the end of the swipe)
* <VC3>.viewWillAppear
* <VC2>.viewWillDisappear
* <VC2>.viewWillAppear
* <VC2>.viewDidAppear
* <VC3>.viewWillDisappear
* <VC3>.viewDidDisappear
* <VC2>.view is shown to the user again

Without this patch, EarlGrey waits for viewDidDisappear: call on <VC2> and app state does not become kGREYIdle.
With this patch, at the call of <VC2>.viewDidAppear state kGREYPendingViewsToDisappear is untracked and app state becomes kGREYIdle.