### PR TITLE
Update RVM to 2.3.0 as it's failing to update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ osx_image: xcode8.3
 matrix:
   global:
     rvm:
-      - 2.2.5
+      - 2.3.0
   include:
     - env:
         - DESTINATION="OS=8.1,name=iPhone 4s" SDK=iphonesimulator10.3 TYPE="FUNCTIONAL"

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_install:
   - rvm install ruby-2.5.3
   - rvm use 2.5.3
   - gem update --system
-  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+  - gem install xcpretty --no-ri --no-document --quiet
 before_script:
   - Scripts/setup-earlgrey.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ osx_image: xcode8.3
 matrix:
   global:
     rvm:
-      - 2.3.0
+      - 2.5.3
   include:
     - env:
         - DESTINATION="OS=8.1,name=iPhone 4s" SDK=iphonesimulator10.3 TYPE="FUNCTIONAL"
@@ -72,8 +72,8 @@ before_install:
         echo "Only doc files were updated, not running the CI."
         exit
       fi
-  - rvm install ruby-2.2.5
-  - rvm use 2.2.5
+  - rvm install ruby-2.5.3
+  - rvm use 2.5.3
   - gem update --system
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_install:
   - rvm install ruby-2.5.3
   - rvm use 2.5.3
   - gem update --system
-  - gem install xcpretty --no-ri --no-document --quiet
+  - gem install xcpretty --no-document --quiet
 before_script:
   - Scripts/setup-earlgrey.sh
 script:


### PR DESCRIPTION
https://travis-ci.org/google/EarlGrey/jobs/471151306:
```
Updating rubygems-update
ERROR:  Error installing rubygems-update:
	rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
The command "gem update --system" failed and exited with 1 during .
```