### PR TITLE
Corrected typos in comments, strings, and docs

### DIFF
--- a/EarlGrey/Action/GREYActions+Internal.h
+++ b/EarlGrey/Action/GREYActions+Internal.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return @c YES if the action succeeded, else @c NO. If an action returns @c NO, it does not
  *          mean that the action was not performed at all but somewhere during the action execution
- *          the error occured and so the UI may be in an unrecoverable state.
+ *          the error occurred and so the UI may be in an unrecoverable state.
  *
  *  @remark This is available only for internal testing purposes.
  */

--- a/EarlGrey/Action/GREYActions.m
+++ b/EarlGrey/Action/GREYActions.m
@@ -396,7 +396,7 @@ static const CFTimeInterval kJavaScriptTimeoutSeconds = 60;
  *
  *  @return @c YES if the action succeeded, else @c NO. If an action returns @c NO, it does not
  *          mean that the action was not performed at all but somewhere during the action execution
- *          the error occured and so the UI may be in an unrecoverable state.
+ *          the error occurred and so the UI may be in an unrecoverable state.
  */
 + (id<GREYAction>)grey_actionForReplaceText:(NSString *)text {
   SEL setTextSelector = NSSelectorFromString(@"setText:");
@@ -474,7 +474,7 @@ static const CFTimeInterval kJavaScriptTimeoutSeconds = 60;
  *
  *  @return @c YES if the action succeeded, else @c NO. If an action returns @c NO, it does not
  *          mean that the action was not performed at all but somewhere during the action execution
- *          the error occured and so the UI may be in an unrecoverable state.
+ *          the error occurred and so the UI may be in an unrecoverable state.
  */
 + (BOOL)grey_disableAutoCorrectForDelegateAndTypeText:(NSString *)text
                                      inFirstResponder:(id)firstResponder

--- a/EarlGrey/Action/GREYPathGestureUtils.m
+++ b/EarlGrey/Action/GREYPathGestureUtils.m
@@ -209,7 +209,7 @@ static CGFloat kCachedScreenEdgePanDetectionLength = NAN;
     return direction;
   }
 
-  // Transform the direction assuming it exists on potrait orientation and we would like to apply
+  // Transform the direction assuming it exists on portrait orientation and we would like to apply
   // it in the current interface orientation.
   UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
   switch (orientation) {

--- a/EarlGrey/Action/GREYScrollAction.m
+++ b/EarlGrey/Action/GREYScrollAction.m
@@ -98,7 +98,7 @@ static const NSInteger kMinTouchPointsToDetectScrollResistance = 2;
   if (![self satisfiesConstraintsForElement:element error:errorOrNil]) {
     return NO;
   }
-  // To scroll UIWebView we must use the UIScrollView in its heirarchy and scroll it.
+  // To scroll UIWebView we must use the UIScrollView in its hierarchy and scroll it.
   if ([element isKindOfClass:[UIWebView class]]) {
     element = [(UIWebView *)element scrollView];
   }

--- a/EarlGrey/Action/GREYScrollToContentEdgeAction.m
+++ b/EarlGrey/Action/GREYScrollToContentEdgeAction.m
@@ -78,7 +78,7 @@
   if (![self satisfiesConstraintsForElement:element error:errorOrNil]) {
     return NO;
   }
-  // To scroll UIWebView we must use the UIScrollView in its heirarchy and scroll it.
+  // To scroll UIWebView we must use the UIScrollView in its hierarchy and scroll it.
   if ([element isKindOfClass:[UIWebView class]]) {
     element = [(UIWebView *)element scrollView];
   }
@@ -108,7 +108,7 @@
     // We have reached the content edge.
     return YES;
   } else {
-    // Some other error has occured.
+    // Some other error has occurred.
     if (errorOrNil) {
       *errorOrNil = scrollError;
     }

--- a/EarlGrey/Action/GREYTapAction.h
+++ b/EarlGrey/Action/GREYTapAction.h
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  A GREYAction that performs a long press with a given @c duration at the given @c location.
  *
  *  @param duration The duration of the long press.
- *  @param location The location of the long press relative to the element recieving the touch
+ *  @param location The location of the long press relative to the element receiving the touch
  *                  event.
  *
  *  @return An instance of GREYTapAction, initialized with the @c duration and @c location of
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param tapType      The type of the tap.
  *  @param numberOfTaps Number of times the element should be tapped.
  *  @param duration     The duration of the tap event if applicable.
- *  @param tapLocation  The location of the tap relative to the element recieving the touch
+ *  @param tapLocation  The location of the tap relative to the element receiving the touch
  *                      event.
  *
  *  @return An initialized (to the given parameters) instance of GREYTapAction.

--- a/EarlGrey/Additions/XCTestCase+GREYAdditions.h
+++ b/EarlGrey/Additions/XCTestCase+GREYAdditions.h
@@ -108,8 +108,8 @@ typedef NS_ENUM(NSUInteger, GREYXCTestCaseStatus) {
  *  Interrupts the current test case execution immediately and triggers XCTest's error handling
  *  mechanism to invoke the appropriate methods to tear down the test.
  *
- *  @param line        Line number at which the failure occured.
- *  @param file        Name of the file in which the failure occured.
+ *  @param line        Line number at which the failure occurred.
+ *  @param file        Name of the file in which the failure occurred.
  *  @param description Full description of the failure.
  */
 - (void)grey_markAsFailedAtLine:(NSUInteger)line

--- a/EarlGrey/Common/GREYAnalytics.m
+++ b/EarlGrey/Common/GREYAnalytics.m
@@ -39,7 +39,7 @@ static NSString *const kTrackingEndPoint = @"https://ssl.google-analytics.com/co
 @end
 
 @implementation GREYAnalytics {
-  // Overriden GREYAnalytics delegate for custom handling of analytics.
+  // Overridden GREYAnalytics delegate for custom handling of analytics.
   __weak id<GREYAnalyticsDelegate> _delegate;
   // Once set, analytics will be sent on next XCTestCase tearDown.
   BOOL _earlgreyWasCalledInXCTestContext;

--- a/EarlGrey/Common/GREYAppleInternals.h
+++ b/EarlGrey/Common/GREYAppleInternals.h
@@ -50,7 +50,7 @@ typedef UInt32 IOOptionBits;
 /**
  *  Event mask detailing the events being dispatched by a digitizer. It is possible for digitizer
  *  events to contain child digitizer events, effectively, behaving as collections. In the
- *  collection case, the child event mask field referrence by
+ *  collection case, the child event mask field reference by
  *  kIOHIDEventFieldDigitizerChildEventMask will detail the cumulative event state of the child
  *  digitizer events. If you append a child digitizer event to a parent digitizer event, appropriate
  *  state will be transferred on to the parent.
@@ -203,7 +203,7 @@ IOHIDEventRef IOHIDEventCreateDigitizerFingerEvent(CFAllocatorRef allocator,
  *  after user stopped dragging it. @c notify determines whether UIScrollViewDelegate will be
  *  notified that scrolling has finished.
  *
- *  @param notify An indicator specifiying if scrolling has finished.
+ *  @param notify An indicator specifying if scrolling has finished.
  */
 - (void)_stopScrollDecelerationNotify:(BOOL)notify;
 @end

--- a/EarlGrey/Common/GREYConfiguration.m
+++ b/EarlGrey/Common/GREYConfiguration.m
@@ -42,9 +42,9 @@ NSString *const kGREYConfigKeyArtifactsDirLocation = @"GREYConfigKeyArtifactsDir
 @implementation GREYConfiguration {
   NSMutableDictionary *_defaultConfiguration; // Dict for storing the default configs
   NSMutableDictionary *_overridenConfiguration; // Dict for storing the user-defined overrides
-  NSMutableDictionary *_mergedConfiguration; // Dict for storing the merged default/overriden dicts
+  NSMutableDictionary *_mergedConfiguration; // Dict for storing the merged default/overridden dicts
   BOOL _needsMerge; // Indicates whether the merged configuration was invalidated due to a change
-                    // in the default or overriden configurations
+                    // in the default or overridden configurations
 }
 
 - (instancetype)init {

--- a/EarlGrey/Core/GREYElementInteraction.m
+++ b/EarlGrey/Core/GREYElementInteraction.m
@@ -214,7 +214,7 @@
     NSError *executorError;
     __block NSError *actionError = nil;
 
-    // Create the user info dictionary for any notificatons and set it up with the action.
+    // Create the user info dictionary for any notifications and set it up with the action.
     NSMutableDictionary *actionUserInfo = [[NSMutableDictionary alloc] init];
     [actionUserInfo setObject:action forKey:kGREYActionUserInfoKey];
     NSNotificationCenter *defaultNotificationCenter = [NSNotificationCenter defaultCenter];
@@ -369,7 +369,7 @@
       id element = (elements.count != 0) ?
       [strongSelf grey_uniqueElementInMatchedElements:elements andError:&assertionError] : nil;
 
-      // Create the user info dictionary for any notificatons and set it up with the assertion.
+      // Create the user info dictionary for any notifications and set it up with the assertion.
       NSMutableDictionary *assertionUserInfo = [[NSMutableDictionary alloc] init];
       [assertionUserInfo setObject:assertion forKey:kGREYAssertionUserInfoKey];
 

--- a/EarlGrey/Event/GREYTouchInjector.h
+++ b/EarlGrey/Event/GREYTouchInjector.h
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param touchInfo The info that is used to create the UITouch. If it represents a last touch
  *                   in a sequence, the specified @c point value is ignored and injector
- *                   automatically picks the previous point where touch occured to deliver
+ *                   automatically picks the previous point where touch occurred to deliver
  *                   the last touch.
  */
 - (void)enqueueTouchInfoForDelivery:(GREYTouchInfo *)touchInfo;

--- a/EarlGrey/Provider/GREYUIWindowProvider.h
+++ b/EarlGrey/Provider/GREYUIWindowProvider.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)providerWithWindows:(NSArray *)windows;
 
 /**
- *  Class method to get a provider with all the windows currently registed with the app.
+ *  Class method to get a provider with all the windows currently registered with the app.
  *
  *  @return A GREYUIWindowProvider instance populated by all windows currently
  *          registered with the app.

--- a/EarlGrey/Synchronization/GREYDispatchQueueTracker.m
+++ b/EarlGrey/Synchronization/GREYDispatchQueueTracker.m
@@ -91,7 +91,7 @@ static GREYDispatchQueueTracker *grey_getTrackerForQueue(dispatch_queue_t queue)
 }
 
 /**
- *  Overriden implementation of @c dispatch_after that calls into the tracker, if one is found for
+ *  Overridden implementation of @c dispatch_after that calls into the tracker, if one is found for
  *  the dispatch queue passed in.
  *
  *  @param when  Same as @c dispatch_after @c when.
@@ -110,7 +110,7 @@ static void grey_dispatch_after(dispatch_time_t when,
 }
 
 /**
- *  Overriden implementation of @c dispatch_async that calls into the tracker, if one is found for
+ *  Overridden implementation of @c dispatch_async that calls into the tracker, if one is found for
  *  the dispatch queue passed in.
  *
  *  @param queue Same as @c dispatch_async @c queue.
@@ -126,7 +126,7 @@ static void grey_dispatch_async(dispatch_queue_t queue, dispatch_block_t block) 
 }
 
 /**
- *  Overriden implementation of @c dispatch_sync that calls into the tracker, if one is found for
+ *  Overridden implementation of @c dispatch_sync that calls into the tracker, if one is found for
  *  the dispatch queue passed in.
  *
  *  @param queue Same as @c dispatch_sync @c queue.
@@ -142,7 +142,7 @@ static void grey_dispatch_sync(dispatch_queue_t queue, dispatch_block_t block) {
 }
 
 /**
- *  Overriden implementation of @c dispatch_after_f that calls into the tracker, if one is found
+ *  Overridden implementation of @c dispatch_after_f that calls into the tracker, if one is found
  *  for the dispatch queue passed in.
  *
  *  @param when    Same as @c dispatch_after_f @c when.
@@ -163,7 +163,7 @@ static void grey_dispatch_after_f(dispatch_time_t when,
 }
 
 /**
- *  Overriden implementation of @c dispatch_async_f that calls into the tracker, if one is found
+ *  Overridden implementation of @c dispatch_async_f that calls into the tracker, if one is found
  *  for the dispatch queue passed in.
  *
  *  @param queue   Same as @c dispatch_async_f @c queue.
@@ -180,7 +180,7 @@ static void grey_dispatch_async_f(dispatch_queue_t queue, void *context, dispatc
 }
 
 /**
- *  Overriden implementation of @c dispatch_sync_f that calls into the tracker, if one is found
+ *  Overridden implementation of @c dispatch_sync_f that calls into the tracker, if one is found
  *  for the dispatch queue passed in.
  *
  *  @param queue   Same as @c dispatch_sync_f @c queue.

--- a/EarlGrey/Synchronization/GREYRunLoopSpinner.m
+++ b/EarlGrey/Synchronization/GREYRunLoopSpinner.m
@@ -230,9 +230,9 @@ static void (^noopTimerHandler)(CFRunLoopTimerRef timer) = ^(CFRunLoopTimerRef t
  *          starts spinning the run loop in the same mode.
  *
  *  @param mode               The mode that the observer should be added to.
- *  @param beforeSourcesBlock Block that will be invoked when the added observer recieves before-
+ *  @param beforeSourcesBlock Block that will be invoked when the added observer receives before-
  *                            sources callbacks and is not nested.
- *  @param beforeWaitingBlock Block that will be invoked when the added observer recieves before-
+ *  @param beforeWaitingBlock Block that will be invoked when the added observer receives before-
  *                            waiting callbacks and is not nested.
  *
  *  @return The registered observer.

--- a/EarlGrey/Synchronization/GREYUIThreadExecutor.h
+++ b/EarlGrey/Synchronization/GREYUIThreadExecutor.h
@@ -84,7 +84,7 @@ typedef void(^GREYExecBlock)(void);
  *  are in idle.
  *
  *  @remark Be very careful while calling this as you could end up in state where the caller expects
- *          the callee to mark the thread as idle and callee inadvertantly calls
+ *          the callee to mark the thread as idle and callee inadvertently calls
  *          GREYUIThreadExecutor::drainUntilIdle:, in which case it will go into an infinite loop
  *          and the test will have to be force-killed by the test-runner.
  */

--- a/EarlGrey/Traversal/GREYTraversalDFS.h
+++ b/EarlGrey/Traversal/GREYTraversalDFS.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Class method to initialize the object. The hierarchy is unrolled in a DFS fashion and
- *  an internal represenation is created.
+ *  an internal representation is created.
  *
  *  @param element Single UI element whose UI hierarchy needs to be unrolled.
  *

--- a/Scripts/rename-ochamcrestIOS.py
+++ b/Scripts/rename-ochamcrestIOS.py
@@ -60,8 +60,8 @@ def _ChangeFrameworkHeaderFileNames():
   script_header_dir = 'OCHamcrest.framework/Headers/*'
   script_dir = 'OCHamcrest.framework/*'
   file_glob = glob.glob(_FilePathRelativeToScriptDirectory(script_header_dir))
-  extention_glob = glob.glob(_FilePathRelativeToScriptDirectory(script_dir))
-  file_glob.extend(extention_glob)
+  extension_glob = glob.glob(_FilePathRelativeToScriptDirectory(script_dir))
+  file_glob.extend(extension_glob)
   for oc_file in file_glob:
     os.rename(oc_file, oc_file.replace('OCHamcrestIOS', 'OCHamcrest'))
 

--- a/Scripts/travis.sh
+++ b/Scripts/travis.sh
@@ -75,7 +75,7 @@ execute_xcodebuild() {
 
   set +e
   # In case of failure in test's +setUp or +tearDown, Xcode doesn't exit with an error code but logs it.
-  # Add another check to make sure no unexpected failure occured.
+  # Add another check to make sure no unexpected failure occurred.
   $(grep -q -m 1 -ie ".*[1-9]\d* unexpected" xcodebuild.log)
   retval_expected_test_failures=$?
   set -e

--- a/Tests/FunctionalTests/Sources/FTRBaseAnalyticsTest.m
+++ b/Tests/FunctionalTests/Sources/FTRBaseAnalyticsTest.m
@@ -45,7 +45,7 @@ static id<GREYAnalyticsDelegate> gOriginalAnalyticsDelegate;
 static id<GREYAnalyticsDelegate> gTestAnalyticsDelegate;
 
 /**
- *  The current total number of analytics hits recieved.
+ *  The current total number of analytics hits received.
  */
 static volatile NSInteger gTotalHitsReceived;
 

--- a/Tests/FunctionalTests/Sources/FTRPinchViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRPinchViewTest.m
@@ -152,7 +152,7 @@
       break;
 
     default:
-      GREYAssert(NO, @"Unknown comparision result was expected %d", (int)expectedOrder);
+      GREYAssert(NO, @"Unknown comparison result was expected %d", (int)expectedOrder);
   }
 
   GREYAssert(success, @"Image sizes before pinch - %@ and after pinch - %@ must be %@.",

--- a/Tests/FunctionalTests/Sources/FTRUIWebViewTest.m
+++ b/Tests/FunctionalTests/Sources/FTRUIWebViewTest.m
@@ -251,7 +251,7 @@ static const NSTimeInterval kLocalHTMLPageLoadDelay = 10.0;
   XCTAssertFalse(isAsyncRequestPending, @"should not be pending");
 }
 
-// TODO: Temporarily disable the test due to that it fails to dectect the UIWebView is idling.
+// TODO: Temporarily disable the test due to that it fails to detect the UIWebView is idling.
 // Link: https://github.com/google/EarlGrey/issues/365
 - (void)DISABLED_testLongPressLinkInUIWebView {
   // Load local page first.

--- a/Tests/FunctionalTests/TestRig/Sources/FTRCollectionViewLayout.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRCollectionViewLayout.m
@@ -35,7 +35,7 @@
   }
 
   NSInteger charIndex = aChar - 'A';
-  // Compute the char's position from its index. The chars are layed out in a grid of size W X H
+  // Compute the char's position from its index. The chars are laid out in a grid of size W X H
   // where W and H are itemsPerSide.
   NSInteger xIndex = charIndex % itemsPerSide;
   NSInteger yIndex = charIndex / itemsPerSide;

--- a/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.h
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.h
@@ -29,7 +29,7 @@
 /**
  *  Enables (if @c enabled is @c YES) or disables the proxy.
  *
- *  @param enabled A BOOL specifing whether to enable or disable the proxy.
+ *  @param enabled A BOOL specifying whether to enable or disable the proxy.
  */
 + (void)ftr_setProxyEnabled:(BOOL)enabled;
 
@@ -58,7 +58,7 @@
 
 /**
  *  @return Returns an array of all the requests proxied since the proxy was enabled or since it
- *          was last cleared which ever happend the last.
+ *          was last cleared which ever happened the last.
  */
 + (NSArray *)ftr_requestsReceived;
 

--- a/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.m
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRNetworkProxy.m
@@ -48,7 +48,7 @@ static NSString *const kFTRNetworkProxyRuleRegexKey = @"kFTRNetworkProxyRuleRege
 static NSString *const kFTRNetworkProxyRuleResponseKey = @"kFTRNetworkProxyRuleResponseKey";
 
 /**
- *  Error domain for errors occuring in FTRNetworkProxy.
+ *  Error domain for errors occurring in FTRNetworkProxy.
  */
 static NSString *const kFTRNetworkProxyErrorDomain =
     @"com.google.earlgrey.FTRNetworkProxyErrorDomain";

--- a/Tests/FunctionalTests/TestRig/Sources/FTRSliderViewController.h
+++ b/Tests/FunctionalTests/TestRig/Sources/FTRSliderViewController.h
@@ -15,7 +15,7 @@
 //
 
 // Class that controls FTRSliderViewController.xib view. The view contains six sliders, each of
-// which have propeties listed below. The top slider is slider1 and the bottom most slider6.
+// which have properties listed below. The top slider is slider1 and the bottom most slider6.
 
 #import <UIKit/UIKit.h>
 

--- a/Tests/UnitTests/Sources/CALayer+GREYAdditionsTest.m
+++ b/Tests/UnitTests/Sources/CALayer+GREYAdditionsTest.m
@@ -402,7 +402,7 @@ static const CFTimeInterval kMaxAnimationInterval = 5.0;
   XCTAssertTrue(state & kGREYPendingCAAnimation,
                 @"State should change after starting an animation.");
 
-  // Clear the state change that happend after adding animation.
+  // Clear the state change that happened after adding animation.
   [[GREYAppStateTracker sharedInstance] grey_clearState];
 
   // iOS creates immutable animation objects from added animations.

--- a/Tests/UnitTests/Sources/CGGeometry+GREYAdditionsTest.m
+++ b/Tests/UnitTests/Sources/CGGeometry+GREYAdditionsTest.m
@@ -85,7 +85,7 @@
     {CGRectMake(5, 6, (CGFloat)0.5, (CGFloat)0.5), CGRectMake(5, 6, 0, 0)},
     {CGRectMake((CGFloat)5.99, (CGFloat)6.99, (CGFloat).49, (CGFloat).49), CGRectMake(6, 7, 0, 0)},
 
-    // inputs w/ non-shrinking-greater-than-1 widths: the compromized width can compensate itself
+    // inputs w/ non-shrinking-greater-than-1 widths: the compromised width can compensate itself
     {CGRectMake((CGFloat)5.9, (CGFloat)5.9, (CGFloat)1.1, (CGFloat)1.1), CGRectMake(6, 6, 1, 1)},
     {CGRectMake((CGFloat).95, (CGFloat)0.95, (CGFloat)10.1, (CGFloat)10.1),
       CGRectMake(1, 1, 10, 10)},

--- a/Tests/UnitTests/Sources/NSObject+GREYAdditionsTest.m
+++ b/Tests/UnitTests/Sources/NSObject+GREYAdditionsTest.m
@@ -212,7 +212,7 @@
   UIAccessibilityElement *element =
       [[UIAccessibilityElement alloc] initWithAccessibilityContainer:container];
 
-  // Set up heirarchy: containersContainer -> container -> element
+  // Set up hierarchy: containersContainer -> container -> element
   element.accessibilityContainer = container;
   container.accessibilityContainer = containersContainer;
   XCTAssertEqualObjects([element grey_viewContainingSelf], containersContainer);
@@ -226,7 +226,7 @@
       [[UIAccessibilityElement alloc] initWithAccessibilityContainer:viewContainer];
   id webViewContainer = [OCMockObject mockForClass:NSClassFromString(@"UIWebView")];
 
-  // Set up heirarchy: webViewContainer -> viewContainer -> container -> element
+  // Set up hierarchy: webViewContainer -> viewContainer -> container -> element
   [[[element stub] andReturn:container] grey_container];
   [[[viewContainer stub] andReturn:webViewContainer] grey_container];
   [[[webViewContainer stub] andReturn:nil] grey_container];


### PR DESCRIPTION
Non-comment code changes are limited to:
  * local variable rename in `Scripts/rename-ochamcrestIOS.py`.
  * string value change in `Tests/FunctionalTests/Sources/FTRPinchViewTest.m`