### PR TITLE
Fix further NSURLSession swizzling woes

### DIFF
--- a/EarlGrey/Additions/NSURLSession+GREYAdditions.m
+++ b/EarlGrey/Additions/NSURLSession+GREYAdditions.m
@@ -54,12 +54,12 @@ typedef void (^GREYTaskCompletionBlock)(NSData *data, NSURLResponse *response, N
   // Swizzle the session delegate class if not yet done.
   id delegate = self.delegate;
   SEL originalSel = @selector(URLSession:task:didCompleteWithError:);
-  // This is to solve issues where there is a proxy delegate instead of the original instance (e.g. TrustKit, New Relic).
-  // It responds YES to `respondsToSelector:` but `class_getInstanceMethod` returns nil.
-  // We attempt to follow the forwarding targets for the selector, if any exists.
+  // This is to solve issues where there is a proxy delegate instead of the original
+  // instance (e.g. TrustKit, New Relic). It responds YES to `respondsToSelector:`
+  // but `class_getInstanceMethod` returns nil. We attempt to follow the forwarding
+  // targets for the selector, if any exists.
   id nextForwardingDelegate;
-  while ((nextForwardingDelegate = [delegate forwardingTargetForSelector:originalSel]))
-  {
+  while ((nextForwardingDelegate = [delegate forwardingTargetForSelector:originalSel])) {
     delegate = nextForwardingDelegate;
   }
   Class delegateClass = [delegate class];

--- a/EarlGrey/Additions/NSURLSession+GREYAdditions.m
+++ b/EarlGrey/Additions/NSURLSession+GREYAdditions.m
@@ -57,8 +57,8 @@ typedef void (^GREYTaskCompletionBlock)(NSData *data, NSURLResponse *response, N
   // This is to solve issues where there is a proxy delegate instead of the original instance (e.g. TrustKit, New Relic).
   // It responds YES to `respondsToSelector:` but `class_getInstanceMethod` returns nil.
   // We attempt to follow the forwarding targets for the selector, if any exists.
-  id nextForwardingDelegate = nil;
-  while((nextForwardingDelegate = [delegate forwardingTargetForSelector:originalSel]) != nil)
+  id nextForwardingDelegate;
+  while ((nextForwardingDelegate = [delegate forwardingTargetForSelector:originalSel]))
   {
     delegate = nextForwardingDelegate;
   }


### PR DESCRIPTION
Following #710, a new issue was discovered when Earl Grey is linked together with New Relic. This PR fixes the bug by actually selecting the correct `delegate` object and querying correctly if that object responds to the original selector.

Closes #839