### PR TITLE
Use a runtime check when swizzling viewWillAppear.

### DIFF
--- a/EarlGrey/Additions/UIViewController+GREYAdditions.m
+++ b/EarlGrey/Additions/UIViewController+GREYAdditions.m
@@ -76,11 +76,11 @@ static Class gInputAccessoryVCClass;
 }
 
 __attribute__((constructor)) static void initialize(void) {
-#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000)
-  gInputAccessoryVCClass = NSClassFromString(@"UIEditingOverlayViewController");
-#else
-  gInputAccessoryVCClass = NSClassFromString(@"UICompatibilityInputViewController");
-#endif
+  if (iOS13_OR_ABOVE()) {
+    gInputAccessoryVCClass = NSClassFromString(@"UIEditingOverlayViewController");
+  } else {
+    gInputAccessoryVCClass = NSClassFromString(@"UICompatibilityInputViewController");
+  }
 }
 
 - (void)grey_trackAsRootViewControllerForWindow:(UIWindow *)window {


### PR DESCRIPTION
The swizzled implementation ignores a specific keyboard-related class,
and the exact class to ignore changed in iOS 13.  Use a runtime test to
choose which class to ignore, rather than a compile-time guard.

This fixes EG1 tests when compiling against the iOS 12 SDK but running
on iOS 13 (or when compiling with the iOS 13 SDK and running on iOS 12).