### PR TITLE
Updates AppFramework to compile with a deployment target of 11.0.

### DIFF
--- a/AppFramework/Additions/UIViewController+GREYApp.m
+++ b/AppFramework/Additions/UIViewController+GREYApp.m
@@ -139,7 +139,13 @@ __attribute__((constructor)) static void initialize(void) {
                 UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToAppear, object);
               }
             };
-        [coordinator notifyWhenInteractionEndsUsingBlock:contextBlock];
+        if (@available(iOS 10.0, *)) {
+          [coordinator notifyWhenInteractionChangesUsingBlock:contextBlock];
+#if !defined(__IPHONE_10_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
+        } else {
+          [coordinator notifyWhenInteractionEndsUsingBlock:contextBlock];
+#endif
+        }
       }
 
       GREYAppStateTrackerObject *object = TRACK_STATE_FOR_OBJECT(kGREYPendingViewsToAppear, self);
@@ -178,7 +184,13 @@ __attribute__((constructor)) static void initialize(void) {
               UNTRACK_STATE_FOR_OBJECT(kGREYPendingViewsToDisappear, object);
             }
           };
-      [coordinator notifyWhenInteractionEndsUsingBlock:contextBlock];
+      if (@available(iOS 10.0, *)) {
+        [coordinator notifyWhenInteractionChangesUsingBlock:contextBlock];
+#if !defined(__IPHONE_10_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0
+      } else {
+        [coordinator notifyWhenInteractionEndsUsingBlock:contextBlock];
+#endif
+      }
     }
 
     GREYAppStateTrackerObject *object = TRACK_STATE_FOR_OBJECT(kGREYPendingViewsToDisappear, self);


### PR DESCRIPTION
A UIViewControllerTransitionCoordinator method was renamed in iOS 10.0
and the old method was deprecated.  Calls to this method are now gated
with compile-time guards and runtime checks to ensure that the code can
compile with any deployment target and still run properly on older iOS
versions.