### PR TITLE
[FIX] Add GREYTraversalProperties to xcodeproj

### DIFF
--- a/EarlGrey.xcodeproj/project.pbxproj
+++ b/EarlGrey.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6F49FDBD22E69D4E00CCE813 /* GREYDiagnosable.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F49FDBC22E69D4C00CCE813 /* GREYDiagnosable.m */; };
 		6F8818B222B86F530006932D /* GREYAssertionBlock+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F8818B122B86F520006932D /* GREYAssertionBlock+Private.h */; };
 		A20847B422BC095B00DD3983 /* GREYTraversalObject.m in Sources */ = {isa = PBXBuildFile; fileRef = A20847B322BC095A00DD3983 /* GREYTraversalObject.m */; };
+		A277771E238FE215003E7373 /* GREYTraversalProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = A277771C238FE215003E7373 /* GREYTraversalProperties.m */; };
 		FD1184D3212CEE72004CADC3 /* XCUIApplication+GREYEnvironment.m in Sources */ = {isa = PBXBuildFile; fileRef = FD1184D2212CEE72004CADC3 /* XCUIApplication+GREYEnvironment.m */; };
 		FD2E76EC2149E4580063EF7E /* GREYAppConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FD2E76EA2149E4580063EF7E /* GREYAppConfiguration.m */; };
 		FD2E76ED2149E4580063EF7E /* GREYAppConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = FD2E76EB2149E4580063EF7E /* GREYAppConfiguration.h */; };
@@ -400,6 +401,8 @@
 		80E8CD4422AF097000CDE5C5 /* GREYElementMatcherBlock+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "GREYElementMatcherBlock+Private.h"; path = "CommonLib/Matcher/GREYElementMatcherBlock+Private.h"; sourceTree = SOURCE_ROOT; };
 		A20847AA22BC095A00DD3983 /* GREYTraversalObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GREYTraversalObject.h; sourceTree = "<group>"; };
 		A20847B322BC095A00DD3983 /* GREYTraversalObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GREYTraversalObject.m; sourceTree = "<group>"; };
+		A277771C238FE215003E7373 /* GREYTraversalProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GREYTraversalProperties.m; sourceTree = "<group>"; };
+		A277771D238FE215003E7373 /* GREYTraversalProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GREYTraversalProperties.h; sourceTree = "<group>"; };
 		FD1184CB212CEE72004CADC3 /* XCUIApplication+GREYEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XCUIApplication+GREYEnvironment.h"; path = "XCTestCase/XCUIApplication+GREYEnvironment.h"; sourceTree = "<group>"; };
 		FD1184D2212CEE72004CADC3 /* XCUIApplication+GREYEnvironment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "XCUIApplication+GREYEnvironment.m"; path = "XCTestCase/XCUIApplication+GREYEnvironment.m"; sourceTree = "<group>"; };
 		FD2E76EA2149E4580063EF7E /* GREYAppConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GREYAppConfiguration.m; path = Config/GREYAppConfiguration.m; sourceTree = "<group>"; };
@@ -1398,6 +1401,8 @@
 		FDF9E04720F82DCA0005DCF2 /* Traversal */ = {
 			isa = PBXGroup;
 			children = (
+				A277771D238FE215003E7373 /* GREYTraversalProperties.h */,
+				A277771C238FE215003E7373 /* GREYTraversalProperties.m */,
 				FD44C48B22C679050044199E /* GREYTraversalFunctions.h */,
 				FD44C48222C679050044199E /* GREYTraversalFunctions.m */,
 				FDF9E05520F82E200005DCF2 /* GREYTraversalBFS.h */,
@@ -1897,6 +1902,7 @@
 				FDB4AB66237CD95F00E6847D /* GREYVisibilityCheckerCacheEntry.m in Sources */,
 				FDF9E05720F82E200005DCF2 /* GREYTraversalDFS.m in Sources */,
 				FDF9E07720F82F030005DCF2 /* GREYElementHierarchy.m in Sources */,
+				A277771E238FE215003E7373 /* GREYTraversalProperties.m in Sources */,
 				FDF9E06220F82E340005DCF2 /* GREYUIWindowProvider.m in Sources */,
 				A20847B422BC095B00DD3983 /* GREYTraversalObject.m in Sources */,
 				FDB4AB67237CD95F00E6847D /* GREYQuickVisibilityChecker.m in Sources */,


### PR DESCRIPTION
After seeing the following error:

Undefined symbols for architecture x86_64:
  “_OBJC_CLASS_$_GREYTraversalViewProperties”, referenced from:
      objc-class-ref in libUILib.a(GREYTraversalFunctions.o)
I fixed it by added GREYTraversalProperties.h and GREYTraversalProperties.m to the project as they were not there.