### PR TITLE
Fix app restart failure and added tests.

### DIFF
--- a/TestLib/XCTestCase/XCUIApplication+GREYEnvironment.m
+++ b/TestLib/XCTestCase/XCUIApplication+GREYEnvironment.m
@@ -23,7 +23,7 @@
   NSString *insertionKey = @"DYLD_INSERT_LIBRARIES";
   NSString *insertionValue = @"@executable_path/Frameworks/AppFramework.framework/AppFramework";
   NSString *alreadyExistingValue = [mutableEnv valueForKey:insertionKey];
-  if (alreadyExistingValue) {
+  if (alreadyExistingValue && ![alreadyExistingValue containsString:insertionValue]) {
     insertionValue = [NSString stringWithFormat:@"%@,%@", alreadyExistingValue, insertionValue];
   }
   [mutableEnv setObject:insertionValue forKey:insertionKey];

--- a/TestLib/XCTestCase/XCUIApplication+GREYEnvironment.m
+++ b/TestLib/XCTestCase/XCUIApplication+GREYEnvironment.m
@@ -23,7 +23,7 @@
   NSString *insertionKey = @"DYLD_INSERT_LIBRARIES";
   NSString *insertionValue = @"@executable_path/Frameworks/AppFramework.framework/AppFramework";
   NSString *alreadyExistingValue = [mutableEnv valueForKey:insertionKey];
-  NSArray *existingValues = [alreadyExistingValue componentsSeparatedByString:@":"];
+  NSArray<NSString *> *existingValues = [alreadyExistingValue componentsSeparatedByString:@":"];
   if (existingValues.count > 0 && ![[NSSet setWithArray:existingValues] containsObject:insertionValue]) {
     insertionValue = [NSString stringWithFormat:@"%@:%@", alreadyExistingValue, insertionValue];
   }

--- a/TestLib/XCTestCase/XCUIApplication+GREYEnvironment.m
+++ b/TestLib/XCTestCase/XCUIApplication+GREYEnvironment.m
@@ -23,8 +23,9 @@
   NSString *insertionKey = @"DYLD_INSERT_LIBRARIES";
   NSString *insertionValue = @"@executable_path/Frameworks/AppFramework.framework/AppFramework";
   NSString *alreadyExistingValue = [mutableEnv valueForKey:insertionKey];
-  if (alreadyExistingValue && ![alreadyExistingValue containsString:insertionValue]) {
-    insertionValue = [NSString stringWithFormat:@"%@,%@", alreadyExistingValue, insertionValue];
+  NSArray *existingValues = [alreadyExistingValue componentsSeparatedByString:@":"];
+  if (existingValues.count > 0 && ![[NSSet setWithArray:existingValues] containsObject:insertionValue]) {
+    insertionValue = [NSString stringWithFormat:@"%@:%@", alreadyExistingValue, insertionValue];
   }
   [mutableEnv setObject:insertionValue forKey:insertionKey];
   self.launchEnvironment = [mutableEnv copy];

--- a/Tests/Functional/Sources/ApplicationStateHandlingTest.m
+++ b/Tests/Functional/Sources/ApplicationStateHandlingTest.m
@@ -78,6 +78,9 @@
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
+#pragma mark - Test app relaunch
+// Test lauching app post termination without causing issues in loading
+// the `AppFramework` library injected using DYLD_INSERT_LIBRARIES.
 - (void)testApplicationRestartOnce {
   [_application terminate];
   [_application launch];
@@ -85,6 +88,7 @@
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
+//Test by relaunching twice.
 - (void)testApplicationRestartTwice {
   [_application terminate];
   [_application launch];
@@ -96,6 +100,7 @@
   [[EarlGrey selectElementWithMatcher:grey_keyWindow()]
       assertWithMatcher:grey_sufficientlyVisible()];
 }
+#pragma mark - End Test app relaunch
 
 - (void)openBottomDockInLandscape:(BOOL)isLandscape {
   XCUIApplication *springboardApplication =

--- a/Tests/Functional/Sources/ApplicationStateHandlingTest.m
+++ b/Tests/Functional/Sources/ApplicationStateHandlingTest.m
@@ -79,8 +79,10 @@
 }
 
 #pragma mark - Test app relaunch
-// Test lauching app post termination without causing issues in loading
-// the `AppFramework` library injected using DYLD_INSERT_LIBRARIES.
+/**
+ * Test lauching app post termination without causing issues in loading
+ * the `AppFramework` library injected using DYLD_INSERT_LIBRARIES.
+ */
 - (void)testApplicationRestartOnce {
   [_application terminate];
   [_application launch];
@@ -88,7 +90,9 @@
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
-//Test by relaunching twice.
+/**
+ * Test by relaunching twice.
+ */
 - (void)testApplicationRestartTwice {
   [_application terminate];
   [_application launch];

--- a/Tests/Functional/Sources/ApplicationStateHandlingTest.m
+++ b/Tests/Functional/Sources/ApplicationStateHandlingTest.m
@@ -78,6 +78,25 @@
       assertWithMatcher:grey_sufficientlyVisible()];
 }
 
+- (void)testApplicationRestartOnce {
+  [_application terminate];
+  [_application launch];
+  [[EarlGrey selectElementWithMatcher:grey_keyWindow()]
+      assertWithMatcher:grey_sufficientlyVisible()];
+}
+
+- (void)testApplicationRestartTwice {
+  [_application terminate];
+  [_application launch];
+  [[EarlGrey selectElementWithMatcher:grey_keyWindow()]
+      assertWithMatcher:grey_sufficientlyVisible()];
+    
+  [_application terminate];
+  [_application launch];
+  [[EarlGrey selectElementWithMatcher:grey_keyWindow()]
+      assertWithMatcher:grey_sufficientlyVisible()];
+}
+
 - (void)openBottomDockInLandscape:(BOOL)isLandscape {
   XCUIApplication *springboardApplication =
       [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];

--- a/Tests/Functional/Sources/ApplicationStateHandlingTest.m
+++ b/Tests/Functional/Sources/ApplicationStateHandlingTest.m
@@ -79,9 +79,10 @@
 }
 
 #pragma mark - Test app relaunch
+
 /**
- * Test lauching app post termination without causing issues in loading
- * the `AppFramework` library injected using DYLD_INSERT_LIBRARIES.
+ *  Test launching app post termination without causing issues in loading
+ *  the `AppFramework` library injected using DYLD_INSERT_LIBRARIES.
  */
 - (void)testApplicationRestartOnce {
   [_application terminate];
@@ -91,7 +92,7 @@
 }
 
 /**
- * Test by relaunching twice.
+ *  Test by relaunching twice.
  */
 - (void)testApplicationRestartTwice {
   [_application terminate];
@@ -104,6 +105,7 @@
   [[EarlGrey selectElementWithMatcher:grey_keyWindow()]
       assertWithMatcher:grey_sufficientlyVisible()];
 }
+
 #pragma mark - End Test app relaunch
 
 - (void)openBottomDockInLandscape:(BOOL)isLandscape {


### PR DESCRIPTION
This PR fixes an issue (#1042) where if the app under test is relaunched, `EarlGrey` would not be able to communicate with it and aborts the test.

This was due to wrong path of `AppFramework` being loaded in application under test during subsequent launches which was causing AppFramework to not be loaded with error:

>"dyld: warning: could not load inserted library '@executable_path/Frameworks/AppFramework.framework/AppFramework,@executable_path/Frameworks/AppFramework.framework/AppFramework' into hardened process because image not found"

More details are in this [comment](https://github.com/google/EarlGrey/issues/1042#issuecomment-572653860)