### PR TITLE
[#1256] - Add quotes to use of PROJECT_DIR variable  in the build pha…

### DIFF
--- a/EarlGrey.xcodeproj/project.pbxproj
+++ b/EarlGrey.xcodeproj/project.pbxproj
@@ -1125,7 +1125,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${PROJECT_DIR}\n./Scripts/setup-earlgrey.sh";
+			shellScript = "cd \"${PROJECT_DIR}\"\n./Scripts/setup-earlgrey.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
…se that runs the setup-earlgrey.sh script, enabling paths that contain spaces to be valid

Fixes #1256. Have signed the CLA.