### PR TITLE
removed bundle ID from console output for error handling

### DIFF
--- a/CommonLib/Error/GREYError+Private.h
+++ b/CommonLib/Error/GREYError+Private.h
@@ -60,16 +60,6 @@ GREY_EXTERN NSString *const kErrorFunctionNameKey;
 GREY_EXTERN NSString *const kErrorUserInfoKey;
 
 /**
- * Key used to retrieve the error info from an error object dictionary.
- */
-GREY_EXTERN NSString *const kErrorErrorInfoKey;
-
-/**
- * Key used to retrieve the bundle ID from an error object dictionary.
- */
-GREY_EXTERN NSString *const kErrorBundleIDKey;
-
-/**
  * Key used to retrieve the stack trace from an error object dictionary.
  */
 GREY_EXTERN NSString *const kErrorStackTraceKey;
@@ -97,7 +87,6 @@ GREY_EXTERN NSString *const kErrorDescriptionGlossaryKey;
 @property(nonatomic) NSUInteger line;
 @property(nonatomic) NSString *functionName;
 @property(nonatomic) NSDictionary *errorInfo;
-@property(nonatomic) NSString *bundleID;
 @property(nonatomic) NSArray *stackTrace;
 @property(nonatomic) NSString *appUIHierarchy;
 @property(nonatomic) NSDictionary *appScreenshots;

--- a/CommonLib/Error/GREYError+Private.h
+++ b/CommonLib/Error/GREYError+Private.h
@@ -60,6 +60,11 @@ GREY_EXTERN NSString *const kErrorFunctionNameKey;
 GREY_EXTERN NSString *const kErrorUserInfoKey;
 
 /**
+ * Key used to retrieve the error info from an error object dictionary.
+ */
+GREY_EXTERN NSString *const kErrorErrorInfoKey;
+
+/**
  * Key used to retrieve the stack trace from an error object dictionary.
  */
 GREY_EXTERN NSString *const kErrorStackTraceKey;

--- a/CommonLib/Error/GREYError.h
+++ b/CommonLib/Error/GREYError.h
@@ -184,11 +184,6 @@ GREY_EXTERN NSString *const kGREYScreenshotActualAfterImage;
 @property(nonatomic, readonly) NSDictionary *errorInfo;
 
 /**
- * The bundle identifier where the error is generated in.
- */
-@property(nonatomic, readonly) NSString *bundleID;
-
-/**
  * The stack trace when the error is generated.
  */
 @property(nonatomic, readonly) NSArray *stackTrace;

--- a/CommonLib/Error/GREYError.m
+++ b/CommonLib/Error/GREYError.m
@@ -40,7 +40,6 @@ NSString *const kErrorLineKey = @"Line";
 NSString *const kErrorFunctionNameKey = @"Function Name";
 NSString *const kErrorUserInfoKey = @"User Info";
 NSString *const kErrorErrorInfoKey = @"Error Info";
-NSString *const kErrorBundleIDKey = @"Bundle ID";
 NSString *const kErrorStackTraceKey = @"Stack Trace";
 NSString *const kErrorAppUIHierarchyKey = @"App UI Hierarchy";
 NSString *const kErrorAppScreenShotsKey = @"App Screenshots";
@@ -64,7 +63,6 @@ NSString *const kGREYScreenshotActualAfterImage =
 @property(nonatomic, readwrite) NSUInteger line;
 @property(nonatomic, readwrite) NSString *functionName;
 @property(nonatomic, readwrite) NSDictionary *errorInfo;
-@property(nonatomic, readwrite) NSString *bundleID;
 @property(nonatomic, readwrite) NSArray *stackTrace;
 @property(nonatomic, readwrite) NSString *appUIHierarchy;
 @property(nonatomic, readwrite) NSDictionary *appScreenshots;
@@ -80,7 +78,6 @@ GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userI
   error.filePath = filePath;
   error.line = line;
   error.functionName = functionName;
-  error.bundleID = [[NSBundle mainBundle] bundleIdentifier];
   error.errorInfo = errorInfo;
   error.stackTrace = stackTrace;
   error.appUIHierarchy = appUIHierarchy;
@@ -95,7 +92,6 @@ GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userI
   NSUInteger _line;
   NSString *_functionName;
   NSDictionary *_errorInfo;
-  NSString *_bundleID;
   NSArray *_stackTrace;
   NSString *_appUIHierarchy;
   NSDictionary *_appScreenshots;
@@ -134,7 +130,6 @@ GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userI
   descriptionDictionary[kErrorFunctionNameKey] = _functionName;
   descriptionDictionary[kErrorUserInfoKey] = self.userInfo;
   descriptionDictionary[kErrorErrorInfoKey] = _errorInfo;
-  descriptionDictionary[kErrorBundleIDKey] = _bundleID;
   descriptionDictionary[kErrorStackTraceKey] = _stackTrace;
   descriptionDictionary[kErrorAppUIHierarchyKey] = _appUIHierarchy;
   descriptionDictionary[kErrorAppScreenShotsKey] = _appScreenshots;
@@ -162,7 +157,6 @@ GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userI
 
     [mutableDescriptions removeObjectForKey:kErrorUserInfoKey];
     [mutableDescriptions removeObjectForKey:kErrorErrorInfoKey];
-    [mutableDescriptions removeObjectForKey:kErrorBundleIDKey];
     [mutableDescriptions removeObjectForKey:kErrorStackTraceKey];
     [mutableDescriptions removeObjectForKey:kErrorAppUIHierarchyKey];
     [mutableDescriptions removeObjectForKey:kErrorAppScreenShotsKey];

--- a/TestLib/Exception/GREYFailureFormatter.m
+++ b/TestLib/Exception/GREYFailureFormatter.m
@@ -101,9 +101,6 @@
   }
 
   // additional info to format
-  if (![excluding containsObject:kErrorDescriptionKey]) {
-    [logger addObject:[NSString stringWithFormat:@"Bundle ID: %@\n", error.bundleID]];
-  }
   if (![excluding containsObject:kErrorStackTraceKey]) {
     [logger addObject:[NSString stringWithFormat:@"Stack Trace: %@\n", error.stackTrace]];
   }


### PR DESCRIPTION
This removes this:

<img width="472" alt="Screen Shot 2020-05-20 at 4 37 14 PM" src="https://user-images.githubusercontent.com/64929355/82507875-46c1fe00-9ab8-11ea-8178-9126ef12a8eb.png">
