### PR TITLE
Glossary Removal

### DIFF
--- a/AppFramework/Action/GREYActions.m
+++ b/AppFramework/Action/GREYActions.m
@@ -577,10 +577,11 @@ static Protocol *gTextInputProtocol;
               grey_dispatch_sync_on_main_thread(^{
                 elementDescription = [element grey_description];
               });
-              NSString *description = [NSString stringWithFormat:
-                                       @"Keyboard did not appear after tapping on an element."
-                                       @"Are you sure that tapping on this element will bring up the keyboard?"
-                                       @"\nElement: %@", element];
+              NSString *description
+                  = [NSString stringWithFormat:
+                      @"Keyboard did not appear after tapping on an element. "
+                      @"\nAre you sure that tapping on this element will bring up the keyboard?"
+                      @"\nElement: \n%@", element];
               I_GREYPopulateError(errorOrNil, kGREYInteractionErrorDomain,
                                   kGREYInteractionActionFailedErrorCode, description);
               return NO;
@@ -589,7 +590,7 @@ static Protocol *gTextInputProtocol;
 
           // If a position is given, move the text cursor to that position.
           __block id firstResponder = nil;
-          __block NSMutableString *description = nil;
+          __block NSString *description = nil;
           grey_dispatch_sync_on_main_thread(^{
             firstResponder = [[expectedFirstResponderView window] firstResponder];
             if (position) {
@@ -598,9 +599,11 @@ static Protocol *gTextInputProtocol;
                                                                    toPosition:position];
                 [firstResponder setSelectedTextRange:newRange];
               } else {
-                [description appendFormat:@"First Responder of Element does not conform to UITextInput protocol."];
-                [description appendFormat:@"\nFirst Responder: %@", [firstResponder description]];
-                [description appendFormat:@"\nElement: %@", [expectedFirstResponderView description]];
+                description
+                    = [NSString stringWithFormat:
+                        @"First Responder of Element does not conform to UITextInput protocol."
+                        @"\nFirst Responder: %@ \nElement: %@", [firstResponder description],
+                        [expectedFirstResponderView description]];
               }
             }
           });

--- a/AppFramework/Action/GREYChangeStepperAction.m
+++ b/AppFramework/Action/GREYChangeStepperAction.m
@@ -190,8 +190,9 @@
   });
 
   if (!(foundMinusButton && foundPlusButton)) {
-    NSString *description = [NSString stringWithFormat:@"Failed to find stepper buttons in stepper:"
-                                                       @"%@", [stepper description]];
+    NSString *description
+        = [NSString stringWithFormat:@"Failed to find stepper buttons in stepper:\n"
+                                     @"%@", [stepper description]];
     I_GREYPopulateError(error, kGREYInteractionErrorDomain,
                              kGREYInteractionActionFailedErrorCode, description);
     return nil;

--- a/AppFramework/Action/GREYChangeStepperAction.m
+++ b/AppFramework/Action/GREYChangeStepperAction.m
@@ -190,12 +190,10 @@
   });
 
   if (!(foundMinusButton && foundPlusButton)) {
-    NSString *description = [NSString stringWithFormat:@"Failed to find stepper buttons "
-                                                       @"in [Stepper]"];
-    NSDictionary<NSString *, NSString *> *glossary = @{@"[Stepper]" : [stepper description]};
-
-    I_GREYPopulateErrorNoted(error, kGREYInteractionErrorDomain,
-                             kGREYInteractionActionFailedErrorCode, description, glossary);
+    NSString *description = [NSString stringWithFormat:@"Failed to find stepper buttons in stepper:"
+                                                       @"%@", [stepper description]];
+    I_GREYPopulateError(error, kGREYInteractionErrorDomain,
+                             kGREYInteractionActionFailedErrorCode, description);
     return nil;
   }
   return

--- a/AppFramework/Action/GREYMultiFingerSwipeAction.m
+++ b/AppFramework/Action/GREYMultiFingerSwipeAction.m
@@ -107,11 +107,11 @@
       } else {
         NSString *errorDescription =
             [NSString stringWithFormat:
-                          @"Cannot perform multi-finger swipe on view [V], as it has "
-                          @"no window and it isn't a window itself."];
-        I_GREYPopulateErrorNoted(error, kGREYSyntheticEventInjectionErrorDomain,
-                                 kGREYOrientationChangeFailedErrorCode, errorDescription,
-                                 @{@"V" : [element grey_description]});
+                          @"Cannot perform multi-finger swipe on the following view, as it has "
+                          @"no window and it isn't a window itself:"
+                          @"%@", [element grey_description]];
+        I_GREYPopulateError(error, kGREYSyntheticEventInjectionErrorDomain,
+                                 kGREYOrientationChangeFailedErrorCode, errorDescription);
         return;
       }
     }

--- a/AppFramework/Action/GREYMultiFingerSwipeAction.m
+++ b/AppFramework/Action/GREYMultiFingerSwipeAction.m
@@ -108,7 +108,7 @@
         NSString *errorDescription =
             [NSString stringWithFormat:
                           @"Cannot perform multi-finger swipe on the following view, as it has "
-                          @"no window and it isn't a window itself:"
+                          @"no window and it isn't a window itself:\n"
                           @"%@", [element grey_description]];
         I_GREYPopulateError(error, kGREYSyntheticEventInjectionErrorDomain,
                                  kGREYOrientationChangeFailedErrorCode, errorDescription);

--- a/AppFramework/Action/GREYPickerAction.m
+++ b/AppFramework/Action/GREYPickerAction.m
@@ -77,13 +77,11 @@
   NSInteger componentCount = [dataSource numberOfComponentsInPickerView:pickerView];
 
   if (componentCount < _column) {
-    NSString *description = [NSString stringWithFormat:@"Invalid column on [Picker] "
-                                                       @"cannot find the column %lu.",
-                                                       (unsigned long)_column];
-    NSDictionary<NSString *, NSString *> *glossary = @{@"Picker" : [pickerView description]};
-    I_GREYPopulateErrorNoted(error, kGREYInteractionErrorDomain,
-                             kGREYInteractionActionFailedErrorCode, description, glossary);
-
+    NSMutableString *description = [NSMutableString stringWithFormat:@"Failed to Find Picker Column."];
+    [description appendFormat:@"\n\nColumn: %lu", (unsigned long)_column];
+    [description appendFormat:@"\n\nPicker: %@\n", [pickerView description]];
+    I_GREYPopulateError(error, kGREYInteractionErrorDomain,
+                        kGREYInteractionActionFailedErrorCode, description);
     return NO;
   }
 

--- a/AppFramework/Action/GREYPinchAction.m
+++ b/AppFramework/Action/GREYPinchAction.m
@@ -91,7 +91,7 @@ static CGFloat const kPinchScale = (CGFloat)0.8;
         [viewToPinch isKindOfClass:[UIWindow class]] ? (UIWindow *)viewToPinch : viewToPinch.window;
 
     if (!window) {
-      NSString *errorDescription = [NSString stringWithFormat:@"Cannot pinch on this view"
+      NSString *errorDescription = [NSString stringWithFormat:@"Cannot pinch on this view "
                                                               @"as it has no window "
                                                               @"and it isn't a window itself:"
                                                               @"\n%@", element];
@@ -125,7 +125,7 @@ static CGFloat const kPinchScale = (CGFloat)0.8;
                                @"Make sure the element lies in the window"];
     NSString *reason = [NSString
         stringWithFormat:@"Cannot apply pinch action on the element."
-                         @"Error Details: %@", errorDetails];
+                         @"\nError Details: %@", errorDetails];
     I_GREYPopulateError(error, kGREYPinchErrorDomain, kGREYPinchFailedErrorCode, reason);
     return nil;
   }

--- a/AppFramework/Action/GREYPinchAction.m
+++ b/AppFramework/Action/GREYPinchAction.m
@@ -91,12 +91,12 @@ static CGFloat const kPinchScale = (CGFloat)0.8;
         [viewToPinch isKindOfClass:[UIWindow class]] ? (UIWindow *)viewToPinch : viewToPinch.window;
 
     if (!window) {
-      NSString *errorDescription = [NSString stringWithFormat:@"Cannot pinch on [View], "
+      NSString *errorDescription = [NSString stringWithFormat:@"Cannot pinch on this view"
                                                               @"as it has no window "
-                                                              @"and it isn't a window itself."];
-      NSDictionary<NSString *, NSString *> *glossary = @{@"View" : element};
-      I_GREYPopulateErrorNoted(error, kGREYPinchErrorDomain, kGREYPinchFailedErrorCode,
-                               errorDescription, glossary);
+                                                              @"and it isn't a window itself:"
+                                                              @"\n%@", element];
+      I_GREYPopulateError(error, kGREYPinchErrorDomain,
+                          kGREYPinchFailedErrorCode, errorDescription);
       return;
     }
 
@@ -117,29 +117,16 @@ static CGFloat const kPinchScale = (CGFloat)0.8;
                            error:(__strong NSError **)error {
   CGRect pinchActionFrame = CGRectIntersection(view.accessibilityFrame, window.bounds);
   if (CGRectIsNull(pinchActionFrame)) {
-    NSMutableDictionary *errorDetails = [[NSMutableDictionary alloc] init];
-
-    errorDetails[kErrorDetailActionNameKey] = self.name;
-    errorDetails[kErrorDetailElementKey] = [view grey_description];
-    errorDetails[kErrorDetailWindowKey] = window.description;
-    errorDetails[kErrorDetailRecoverySuggestionKey] = @"Make sure the element lies in the window";
-
-    NSArray *keyOrder = @[
-      kErrorDetailActionNameKey, kErrorDetailElementKey, kErrorDetailWindowKey,
-      kErrorDetailRecoverySuggestionKey
-    ];
-
-    NSString *reasonDetail = [GREYObjectFormatter formatDictionary:errorDetails
-                                                            indent:2
-                                                         hideEmpty:YES
-                                                          keyOrder:keyOrder];
-
+    NSMutableString *errorDetails;
+    [errorDetails appendFormat:@"\n%@: %@", kErrorDetailActionNameKey, self.name];
+    [errorDetails appendFormat:@"\n%@: %@", kErrorDetailElementKey, [view grey_description]];
+    [errorDetails appendFormat:@"\n%@: %@", kErrorDetailWindowKey, window.description];
+    [errorDetails appendFormat:@"\n%@: %@", kErrorDetailRecoverySuggestionKey,
+                               @"Make sure the element lies in the window"];
     NSString *reason = [NSString
-        stringWithFormat:@"Cannot apply pinch action on the element. Error: %@\n", reasonDetail];
-
-    I_GREYPopulateErrorNoted(error, kGREYPinchErrorDomain, kGREYPinchFailedErrorCode, reason,
-                             @{@"V" : view});
-
+        stringWithFormat:@"Cannot apply pinch action on the element."
+                         @"Error Details: %@", errorDetails];
+    I_GREYPopulateError(error, kGREYPinchErrorDomain, kGREYPinchFailedErrorCode, reason);
     return nil;
   }
 

--- a/AppFramework/Action/GREYSwipeAction.m
+++ b/AppFramework/Action/GREYSwipeAction.m
@@ -99,14 +99,12 @@
         window = (UIWindow *)element;
       } else {
         NSString *errorDescription =
-            [NSString stringWithFormat:@"Cannot swipe on [View], as it has no window and "
-                                       @"it isn't a window itself."];
-        NSDictionary<NSString *, NSString *> *glossary = @{@"View" : [element grey_description]};
-        GREYError *injectionError =
-            GREYErrorMakeWithHierarchy(kGREYSyntheticEventInjectionErrorDomain,
-                                       kGREYOrientationChangeFailedErrorCode, errorDescription);
-        injectionError.descriptionGlossary = glossary;
-        *error = injectionError;
+            [NSString stringWithFormat:@"Cannot swipe on this view as it has no window and "
+                                       @"isn't a window itself:"
+                                       @"\n%@", [element grey_description]];
+        *error = GREYErrorMakeWithHierarchy(kGREYSyntheticEventInjectionErrorDomain,
+                                            kGREYOrientationChangeFailedErrorCode,
+                                            errorDescription);
         return;
       }
     }

--- a/AppFramework/Action/GREYTapAction.m
+++ b/AppFramework/Action/GREYTapAction.m
@@ -142,7 +142,7 @@
       if (!window) {
         NSString *description =
             [NSString stringWithFormat:@"Element is not attached to a window:"
-                                       @"%@", [element grey_description]];
+                                       @"\n%@", [element grey_description]];
         I_GREYPopulateError(error, kGREYInteractionErrorDomain,
                             kGREYInteractionActionFailedErrorCode, description);
         return NO;

--- a/AppFramework/Action/GREYTapAction.m
+++ b/AppFramework/Action/GREYTapAction.m
@@ -142,12 +142,10 @@
       });
       if (!window) {
         NSString *description =
-            [NSString stringWithFormat:@"[Element] is not attached to a window."];
-        NSDictionary<NSString *, NSString *> *glossary = @{@"Element" : [element grey_description]};
-
-        I_GREYPopulateErrorNoted(error, kGREYInteractionErrorDomain,
-                                 kGREYInteractionActionFailedErrorCode, description, glossary);
-
+            [NSString stringWithFormat:@"Element is not attached to a window:"
+                                       @"%@", [element grey_description]];
+        I_GREYPopulateError(error, kGREYInteractionErrorDomain,
+                            kGREYInteractionActionFailedErrorCode, description);
         return NO;
       }
       return [GREYTapper tapOnWindow:window

--- a/AppFramework/Assertion/GREYAssertions.m
+++ b/AppFramework/Assertion/GREYAssertions.m
@@ -38,8 +38,8 @@
     if (![matcher matches:element describingMismatchTo:mismatch]) {
       NSMutableString *reason = [[NSMutableString alloc] init];
       if (!element) {
-        [reason appendFormat:@"Assertion with Matcher failed: No UI element was matched."];
-        [reason appendFormat:@"Matcher: %@", [matcher description]];
+        [reason appendFormat:@"Assertion with Matcher failed: No UI element was matched.\n"];
+        [reason appendFormat:@"Matcher: \n%@", [matcher description]];
         I_GREYPopulateError(errorOrNil, kGREYInteractionErrorDomain,
                             kGREYInteractionElementNotFoundErrorCode, reason);
       } else {

--- a/AppFramework/Assertion/GREYAssertions.m
+++ b/AppFramework/Assertion/GREYAssertions.m
@@ -37,22 +37,15 @@
     GREYStringDescription *mismatch = [[GREYStringDescription alloc] init];
     if (![matcher matches:element describingMismatchTo:mismatch]) {
       NSMutableString *reason = [[NSMutableString alloc] init];
-      NSMutableDictionary<NSString *, NSString *> *glossary = [[NSMutableDictionary alloc] init];
       if (!element) {
-        [reason appendFormat:@"Assertion with [Matcher] failed: No UI element was matched."];
-        glossary[@"Matcher"] = [matcher description];
-
-        I_GREYPopulateErrorNoted(errorOrNil, kGREYInteractionErrorDomain,
-                                 kGREYInteractionElementNotFoundErrorCode, reason, glossary);
+        [reason appendFormat:@"Assertion with Matcher failed: No UI element was matched."];
+        [reason appendFormat:@"Matcher: %@", [matcher description]];
+        I_GREYPopulateError(errorOrNil, kGREYInteractionErrorDomain,
+                            kGREYInteractionElementNotFoundErrorCode, reason);
       } else {
-        [reason appendFormat:@"Assertion with [Matcher] failed: UI [Element] failed to match "
-                             @"the following matcher(s): [Mismatch]"];
-        glossary[@"Matcher"] = [matcher description];
-        glossary[@"Element"] = [element grey_description];
-        glossary[@"Mismatch"] = [mismatch description];
-
-        I_GREYPopulateErrorNoted(errorOrNil, kGREYInteractionErrorDomain,
-                                 kGREYInteractionAssertionFailedErrorCode, reason, glossary);
+        [reason appendFormat:@"An assertion failed."];
+        I_GREYPopulateError(errorOrNil, kGREYInteractionErrorDomain,
+                            kGREYInteractionAssertionFailedErrorCode, reason);
       }
       return NO;
     }

--- a/AppFramework/Core/GREYElementInteraction.m
+++ b/AppFramework/Core/GREYElementInteraction.m
@@ -824,7 +824,7 @@
   if ([interactionError isKindOfClass:[GREYError class]]) {
     wrappedError = I_GREYErrorMake(
         interactionError.domain, interactionError.code, userInfo, interactionError.filePath,
-        interactionError.line, interactionError.functionName, interactionError.descriptionGlossary,
+        interactionError.line, interactionError.functionName,
         interactionError.stackTrace, hierarchy, appScreenshots);
   } else {
     // In case the error is an internal error from a custom matcher or assertion, just convert it

--- a/AppFramework/Error/GREYAppError.h
+++ b/AppFramework/Error/GREYAppError.h
@@ -36,7 +36,7 @@
 #define GREYErrorMakeWithHierarchy(domain, code, description)                          \
   I_GREYErrorMake((domain), (code), @{NSLocalizedDescriptionKey : (description)},      \
                   [NSString stringWithUTF8String:__FILE__], __LINE__,                  \
-                  [NSString stringWithUTF8String:__PRETTY_FUNCTION__], nil,            \
+                  [NSString stringWithUTF8String:__PRETTY_FUNCTION__],                 \
                   [NSThread callStackSymbols], [GREYElementHierarchy hierarchyString], \
                   [GREYFailureScreenshotter screenshots])
 
@@ -62,7 +62,7 @@
       (domain), (code),                                                                           \
       @{NSLocalizedDescriptionKey : (description), NSUnderlyingErrorKey : (nestedError)},         \
       [NSString stringWithUTF8String:__FILE__], __LINE__,                                         \
-      [NSString stringWithUTF8String:__PRETTY_FUNCTION__], nil, [NSThread callStackSymbols], nil, \
+      [NSString stringWithUTF8String:__PRETTY_FUNCTION__], [NSThread callStackSymbols], nil,      \
       nil)
 
 /**
@@ -81,29 +81,6 @@
 #define I_GREYPopulateError(errorRef, domain, code, description)                \
   ({                                                                            \
     GREYError *e = GREYErrorMakeWithHierarchy((domain), (code), (description)); \
-    if (errorRef) {                                                             \
-      *errorRef = e;                                                            \
-    }                                                                           \
-  })
-
-/**
- * If @c errorRef is not @c NULL, it is set to a @c GREYError object that is created with
- * the given @c domain, @c code, @c description and @c note.
- * The description is accessible by querying error's @c userInfo with
- * @c NSLocalizedDescriptionKey.
- *
- * @param[out] errorRef A @c GREYError reference for retrieving the created
- *                      error object.
- * @param domain        The error domain.
- * @param code          The error code.
- * @param description   The error's localized description.
- * @param glossary      A glossary dictionary that is going to be populated with the error.
- *
- */
-#define I_GREYPopulateErrorNoted(errorRef, domain, code, description, glossary) \
-  ({                                                                            \
-    GREYError *e = GREYErrorMakeWithHierarchy((domain), (code), (description)); \
-    e.descriptionGlossary = (glossary);                                         \
     if (errorRef) {                                                             \
       *errorRef = e;                                                            \
     }                                                                           \

--- a/AppFramework/Synchronization/GREYUIThreadExecutor.m
+++ b/AppFramework/Synchronization/GREYUIThreadExecutor.m
@@ -29,6 +29,7 @@
 #import "GREYDefines.h"
 #import "GREYLogger.h"
 #import "GREYStopwatch.h"
+#import "GREYObjectFormatter.h"
 
 // Extern.
 NSString *const kGREYUIThreadExecutorErrorDomain =
@@ -203,10 +204,16 @@ static const CFTimeInterval kMaximumSynchronizationSleepInterval = 0.1;
     if (!isAppIdle) {
       NSOrderedSet *busyResources = [self grey_busyResources];
       if ([busyResources count] > 0) {
-        NSString *description = @"Failed to execute block because idling resources are busy.";
-        I_GREYPopulateErrorNoted(error, kGREYUIThreadExecutorErrorDomain,
-                                 kGREYUIThreadExecutorTimeoutErrorCode, description,
-                                 [self grey_errorDictionaryForBusyResources:busyResources]);
+        NSDictionary *errorDictionary = [self grey_errorDictionaryForBusyResources:busyResources];
+        NSString *busyResources = [GREYObjectFormatter formatDictionary:errorDictionary
+                                                                 indent:2
+                                                              hideEmpty:YES
+                                                               keyOrder:errorDictionary.allKeys];
+        NSString *description = [NSString stringWithFormat:@"Failed to execute block because idling resources are busy.\n%@",
+                                 busyResources];
+        I_GREYPopulateError(error, kGREYUIThreadExecutorErrorDomain,
+                            kGREYUIThreadExecutorTimeoutErrorCode,
+                            description);
       } else {
         I_GREYPopulateError(error, kGREYUIThreadExecutorErrorDomain,
                             kGREYUIThreadExecutorTimeoutErrorCode,

--- a/CommonLib/Error/GREYError+Private.h
+++ b/CommonLib/Error/GREYError+Private.h
@@ -79,11 +79,6 @@ GREY_EXTERN NSString *const kErrorAppUIHierarchyKey;
  */
 GREY_EXTERN NSString *const kErrorAppScreenShotsKey;
 
-/**
- * Key used to retrieve the description glossary from an error object dictionary.
- */
-GREY_EXTERN NSString *const kErrorDescriptionGlossaryKey;
-
 @interface GREYError (Private)
 
 @property(nonatomic) NSString *testCaseClassName;

--- a/CommonLib/Error/GREYError.h
+++ b/CommonLib/Error/GREYError.h
@@ -35,7 +35,7 @@
 #define GREYErrorMake(domain, code, description)                                  \
   I_GREYErrorMake((domain), (code), @{NSLocalizedDescriptionKey : (description)}, \
                   [NSString stringWithUTF8String:__FILE__], __LINE__,             \
-                  [NSString stringWithUTF8String:__PRETTY_FUNCTION__], nil,       \
+                  [NSString stringWithUTF8String:__PRETTY_FUNCTION__],            \
                   [NSThread callStackSymbols], nil, nil)
 
 /**
@@ -49,15 +49,14 @@
  * @param filePath     The file path where the error is generated.
  * @param line         The file line where the error is generated.
  * @param functionName The function name where the error is generated.
- * @param errorInfo    A dictionary containing details about the error.
  * @param stackTrace   The stack trace for the app when the error is generated.
  *
  * @return A @c GREYError object with the given input.
  */
 GREY_EXTERN GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userInfo,
                                        NSString *filePath, NSUInteger line, NSString *functionName,
-                                       NSDictionary *errorInfo, NSArray *stackTrace,
-                                       NSString *appUIHierarchy, NSDictionary *appScreenshots);
+                                       NSArray *stackTrace, NSString *appUIHierarchy,
+                                       NSDictionary *appScreenshots);
 
 /**
  * The string for a generic error in EarlGrey.
@@ -179,11 +178,6 @@ GREY_EXTERN NSString *const kGREYScreenshotActualAfterImage;
 @property(nonatomic, readwrite) NSString *underlyingErrorDescription;
 
 /**
- * The error information dictionary that is associated with the error.
- */
-@property(nonatomic, readonly) NSDictionary *errorInfo;
-
-/**
  * The stack trace when the error is generated.
  */
 @property(nonatomic, readonly) NSArray *stackTrace;
@@ -202,11 +196,6 @@ GREY_EXTERN NSString *const kGREYScreenshotActualAfterImage;
  * Nested error within current error.
  */
 @property(nonatomic, readonly) GREYError *nestedError;
-
-/**
- * The description glossary dictionary that is associated with the error.
- */
-@property(nonatomic) NSDictionary *descriptionGlossary;
 
 /**
  * @remark init is not an available initializer.

--- a/CommonLib/Error/GREYError.m
+++ b/CommonLib/Error/GREYError.m
@@ -43,7 +43,6 @@ NSString *const kErrorErrorInfoKey = @"Error Info";
 NSString *const kErrorStackTraceKey = @"Stack Trace";
 NSString *const kErrorAppUIHierarchyKey = @"App UI Hierarchy";
 NSString *const kErrorAppScreenShotsKey = @"App Screenshots";
-NSString *const kErrorDescriptionGlossaryKey = @"Description Glossary";
 
 NSString *const kGREYAppScreenshotAtFailure = @"App-side Screenshot at Point-of-Failure";
 NSString *const kGREYTestScreenshotAtFailure = @"Test-side Screenshot at Failure";
@@ -71,14 +70,13 @@ NSString *const kGREYScreenshotActualAfterImage =
 
 GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userInfo,
                            NSString *filePath, NSUInteger line, NSString *functionName,
-                           NSDictionary *errorInfo, NSArray *stackTrace, NSString *appUIHierarchy,
+                           NSArray *stackTrace, NSString *appUIHierarchy,
                            NSDictionary *appScreenshots) {
   GREYError *error = [[GREYError alloc] initWithDomain:domain code:code userInfo:userInfo];
 
   error.filePath = filePath;
   error.line = line;
   error.functionName = functionName;
-  error.errorInfo = errorInfo;
   error.stackTrace = stackTrace;
   error.appUIHierarchy = appUIHierarchy;
   error.appScreenshots = appScreenshots;
@@ -133,7 +131,6 @@ GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userI
   descriptionDictionary[kErrorStackTraceKey] = _stackTrace;
   descriptionDictionary[kErrorAppUIHierarchyKey] = _appUIHierarchy;
   descriptionDictionary[kErrorAppScreenShotsKey] = _appScreenshots;
-  descriptionDictionary[kErrorDescriptionGlossaryKey] = _descriptionGlossary;
 
   return descriptionDictionary;
 }
@@ -174,7 +171,7 @@ GREYError *I_GREYErrorMake(NSString *domain, NSInteger code, NSDictionary *userI
   }
 
   NSArray *keyOrder = @[
-    kErrorDescriptionKey, kErrorDescriptionGlossaryKey, kErrorDomainKey, kErrorCodeKey,
+    kErrorDescriptionKey, kErrorDomainKey, kErrorCodeKey,
     kErrorFileNameKey, kErrorFunctionNameKey, kErrorLineKey, kErrorTestCaseClassNameKey,
     kErrorTestCaseMethodNameKey
   ];

--- a/TestLib/EarlGreyImpl/EarlGrey.m
+++ b/TestLib/EarlGreyImpl/EarlGrey.m
@@ -131,27 +131,14 @@ static BOOL ExecuteSyncBlockInBackgroundQueue(BOOL (^block)(void)) {
   if (!success) {
     NSString *errorDescription;
     if (syncErrorBeforeRotation) {
-      NSString *errorReason = @"Application did not idle before rotating.\n%@\n%@";
-      // TODO(b/147072566): Provide an error API to format description glossary on the test side.
-      NSString *descriptionGlossary =
-          [GREYObjectFormatter formatDictionary:syncErrorBeforeRotation.descriptionGlossary
-                                         indent:kGREYObjectFormatIndent
-                                      hideEmpty:YES
-                                       keyOrder:nil];
+      NSString *errorReason = @"Application did not idle before rotating.\n%@";
       errorDescription =
-          [NSString stringWithFormat:errorReason, syncErrorBeforeRotation.localizedDescription,
-                                     descriptionGlossary];
+          [NSString stringWithFormat:errorReason, syncErrorBeforeRotation.localizedDescription];
     } else if (syncErrorAfterRotation) {
       NSString *errorReason =
-          @"Application did not idle after rotating and before verifying the rotation.\n%@@\n%@";
-      NSString *descriptionGlossary =
-          [GREYObjectFormatter formatDictionary:syncErrorBeforeRotation.descriptionGlossary
-                                         indent:kGREYObjectFormatIndent
-                                      hideEmpty:YES
-                                       keyOrder:nil];
+          @"Application did not idle after rotating and before verifying the rotation.\n%@";
       errorDescription =
-          [NSString stringWithFormat:errorReason, syncErrorAfterRotation.localizedDescription,
-                                     descriptionGlossary];
+          [NSString stringWithFormat:errorReason, syncErrorAfterRotation.localizedDescription];
     } else if (!syncErrorBeforeRotation && !syncErrorAfterRotation) {
       NSString *errorReason = @"Could not rotate application to orientation: %tu. XCUIDevice "
                               @"Orientation: %tu UIDevice Orientation: %tu. UIDevice is the "

--- a/TestLib/Exception/GREYFailureFormatter.m
+++ b/TestLib/Exception/GREYFailureFormatter.m
@@ -58,12 +58,12 @@
 
   GREYError *error =
       I_GREYErrorMake(kGREYGenericErrorDomain, kGREYGenericErrorCode, nil, filePath, lineNumber,
-                      functionName, nil, stackTrace, hierarchy, appScreenshots);
+                      functionName, stackTrace, hierarchy, appScreenshots);
   XCTestCase *currentTestCase = [XCTestCase grey_currentTestCase];
   error.testCaseClassName = [currentTestCase grey_testClassName];
   error.testCaseMethodName = [currentTestCase grey_testMethodName];
 
-  NSArray *excluding = @[ kErrorFilePathKey, kErrorLineKey, kErrorDescriptionGlossaryKey ];
+  NSArray *excluding = @[ kErrorFilePathKey, kErrorLineKey ];
   return [self formatFailureForError:error
                            excluding:excluding
                         failureLabel:failureLabel
@@ -155,17 +155,7 @@
       }
     }
   }
-
-  if (![excluding containsObject:kErrorDescriptionGlossaryKey]) {
-    NSString *glossary = [GREYObjectFormatter formatDictionary:error.descriptionGlossary
-                                                        indent:kGREYObjectFormatIndent
-                                                     hideEmpty:YES
-                                                      keyOrder:nil];
-    NSString *glossaryString =
-        [NSString stringWithFormat:@"%@: %@\n", kErrorDescriptionGlossaryKey, glossary];
-    [logger addObject:glossaryString];
-  }
-
+  
   return [logger componentsJoinedByString:@"\n"];
 }
 

--- a/Tests/Functional/HostDOCategories/GREYHostApplicationDistantObject+ErrorHandlingTest.h
+++ b/Tests/Functional/HostDOCategories/GREYHostApplicationDistantObject+ErrorHandlingTest.h
@@ -26,11 +26,6 @@
 - (NSError *)errorPopulatedInTheApp;
 
 /**
- * @c returns A noted error populated by GREYError with the UI Hierarchy.
- */
-- (NSError *)notedErrorPopulatedInTheApp;
-
-/**
  * @c returns A simple error created with the UI Hierarchy.
  */
 - (NSError *)errorCreatedInTheApp;

--- a/Tests/Functional/HostDOCategories/GREYHostApplicationDistantObject+ErrorHandlingTest.m
+++ b/Tests/Functional/HostDOCategories/GREYHostApplicationDistantObject+ErrorHandlingTest.m
@@ -48,12 +48,6 @@
   return error;
 }
 
-- (NSError *)notedErrorPopulatedInTheApp {
-  NSError *error;
-  I_GREYPopulateErrorNoted(&error, kGREYGenericErrorDomain, kGREYGenericErrorCode, @"Foo", @{});
-  return error;
-}
-
 - (NSError *)errorCreatedInTheApp {
   return GREYErrorMakeWithHierarchy(kGREYGenericErrorDomain, kGREYGenericErrorCode, @"Foo");
 }

--- a/Tests/Functional/Sources/ErrorHandlingTest.m
+++ b/Tests/Functional/Sources/ErrorHandlingTest.m
@@ -203,12 +203,6 @@
                  (NSUInteger)1);
 }
 
-- (void)testNestedErrorPopulatedInTheAppContainsOneHierarchy {
-  NSError *error = [[GREYHostApplicationDistantObject sharedInstance] notedErrorPopulatedInTheApp];
-  XCTAssertEqual([self grey_hierarchyOccurrencesInErrorDescription:error.description],
-                 (NSUInteger)1);
-}
-
 - (void)testErrorCreatedInTheAppContainsOneHierarchy {
   NSError *error = [[GREYHostApplicationDistantObject sharedInstance] errorPopulatedInTheApp];
   XCTAssertEqual([self grey_hierarchyOccurrencesInErrorDescription:error.description],

--- a/Tests/Functional/Sources/KeyboardKeysTest.m
+++ b/Tests/Functional/Sources/KeyboardKeysTest.m
@@ -548,7 +548,7 @@
       @"Unexpected error message for second dismiss: %@, original error: %@",
       localizedErrorDescription, error);
 }
- 
+
 - (void)testDismissingKeyboardWhenReturnIsNotPresent {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"KeyboardPicker")]
       performAction:grey_setPickerColumnToValue(0, @"PhonePad")];

--- a/Tests/Functional/Sources/KeyboardKeysTest.m
+++ b/Tests/Functional/Sources/KeyboardKeysTest.m
@@ -146,7 +146,7 @@
     GREYFail(@"Should throw an exception");
   } @catch (NSException *exception) {
     NSRange exceptionRange =
-        [[exception reason] rangeOfString:@"Keyboard did not appear after tapping on [Element]"];
+        [[exception reason] rangeOfString:@"Keyboard did not appear after tapping on an element."];
     GREYAssertTrue(exceptionRange.length > 0,
                    @"Should throw exception indicating keyboard did not appear.");
   }

--- a/Tests/Functional/Sources/KeyboardKeysTest.m
+++ b/Tests/Functional/Sources/KeyboardKeysTest.m
@@ -548,7 +548,7 @@
       @"Unexpected error message for second dismiss: %@, original error: %@",
       localizedErrorDescription, error);
 }
-
+ 
 - (void)testDismissingKeyboardWhenReturnIsNotPresent {
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"KeyboardPicker")]
       performAction:grey_setPickerColumnToValue(0, @"PhonePad")];

--- a/Tests/Functional/Sources/VisibilityTest.m
+++ b/Tests/Functional/Sources/VisibilityTest.m
@@ -108,7 +108,7 @@
   [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"RedBar")]
       assertWithMatcher:grey_interactable()
                   error:&error];
-  XCTAssertTrue([error.description containsString:@"interactable Point:{nan, nan}"]);
+  XCTAssertTrue([error.description containsString:@"interactable Point:{0, 0}"]);
 }
 
 - (void)testVisibilityFailsWhenViewIsObscured {


### PR DESCRIPTION
Description Glossary Removal from Earl Grey Error Handling:

Recently, glossary contents have not been used at all, although they sometimes contain needed information (such as, what was the picker and the column that failed?)

If the glossary contents were important to the user, i added them to the exception reason.
If they weren't, i removed the glossary contents.

I also removed the glossary properties on GREYError, and the user info dictionary property as well being passed into I_GREYErrorMake, and the GREYPopulateErrorNoted macro, all of which were complicating error handling and making errors harder to read.

Example 1, where important info was not being shown, before:

<img width="834" alt="picker-glossary-before" src="https://user-images.githubusercontent.com/64929355/83108169-41deea80-a074-11ea-96f7-0798b5226077.png">

after:

<img width="825" alt="picker-glossary-after" src="https://user-images.githubusercontent.com/64929355/83108179-44d9db00-a074-11ea-86a6-876cd3ca1fa4.png">

Example 2 
this time when the glossary contained too much info, before:

<img width="908" alt="glossary-before" src="https://user-images.githubusercontent.com/64929355/83108384-8ff3ee00-a074-11ea-8d9d-c52a524af96d.png">

and after:

<img width="777" alt="glossary-after" src="https://user-images.githubusercontent.com/64929355/83108401-95e9cf00-a074-11ea-9818-e8de6cfab97f.png">

Of course, in this second example, a followup edit should remove the unnecessary Element Matcher key for this specific error code but that is outside the scope of the glossary removal.

Example 3 - Idling Resources
In this example, the output hasn't changed at all, although the glossary was removed.
<img width="1024" alt="idling" src="https://user-images.githubusercontent.com/64929355/83199845-e0139480-a0f6-11ea-9a6c-10a84c6bdde5.png">

Example 4 - Stepper
If the stepper buttons aren't found, before:
```
Failed to find stepper buttons
in [Stepper]
```
Notice how it wasn't printing out the Stepper that is included in the glossary.
After:
```
Failed to find stepper buttons in stepper: 
<UIStepper: 0x7fdaaf52e030; frame = (205 35; 94 32); clipsToBounds = YES; opaque = NO; autoresize = RM+BM; layer = <CALayer: 0x6000026fa6a0>>
```