### PR TITLE
Fix method call in demo project since deeplink function name changed

### DIFF
--- a/TestLib/Swift/EarlGrey.swift
+++ b/TestLib/Swift/EarlGrey.swift
@@ -153,7 +153,7 @@ public struct EarlGrey {
     line: UInt = #line
   ) throws {
     try EarlGreyImpl.invoked(fromFile: file.description, lineNumber: line)
-      .openDeepLinkURL(url, with: application)
+      .openDeeplinkURL(url, in: application)
   }
 
   public static func remoteClassInApp(


### PR DESCRIPTION
The name for the `openDeeplinkURL(url, in: application)` function changed and it wasn't updated in the demo project. I just updated the line in the demo project.