### PR TITLE
action-error-format

### DIFF
--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -57,7 +57,8 @@ static NSString *const kErrorPrefix = @"EarlGrey Encountered an Error:";
 
 BOOL GREYShouldUseErrorFormatterForError(GREYError *error) {
   return [error.domain isEqualToString:kGREYInteractionErrorDomain] &&
-         error.code == kGREYInteractionElementNotFoundErrorCode;
+         (error.code == kGREYInteractionElementNotFoundErrorCode ||
+          error.code == kGREYInteractionActionFailedErrorCode);
 }
 
 BOOL GREYShouldUseErrorFormatterForDetails(NSString *failureHandlerDetails) {


### PR DESCRIPTION
This change tracks the adoption of GREYErrorFormatter for kGREYInteractionActionFailedErrorCode

Console Output, Before:
```
Exception: com.google.earlgrey.ElementInteractionErrorDomain

Exception Name: com.google.earlgrey.ElementInteractionErrorDomain
Exception Reason: Failed to type because the provided string was empty.
Exception Details: 
Failed to type because the provided string was empty.

Element Matcher:
(respondsToSelector(accessibilityIdentifier) && accessibilityID('foo'))

UI Hierarchy: ...

Screenshots: ...

Stack Trace: ...
````

Console Output, After:

```
EarlGrey Encountered an Error:

Failed to type because the provided string was empty.

Element Matcher:
(respondsToSelector(accessibilityIdentifier) && accessibilityID('foo'))

UI Hierarchy: ...

Screenshots: ...

Stack Trace: ...
```

Note that "EarlGrey Encountered an Error:" is temporary, until all error codes are using GREYErrorFormatter.

A test should be added internally to FailureFormattingTest:
```
- (void)testActionInteractionErrorDescription {
  [[EarlGrey selectElementWithMatcher:grey_text(@"Basic Views")] performAction:grey_tap()];
  [[EarlGrey selectElementWithMatcher:grey_text(@"Tab 2")] performAction:grey_tap()];
  [[EarlGrey selectElementWithMatcher:grey_accessibilityID(@"foo")]
      performAction:grey_typeText(@"")];

  NSString *expectedDetails = @"Failed to type because the provided string was empty.\n"
                              @"\n"
                              @"Element Matcher:\n"
                              @"(respondsToSelector(accessibilityIdentifier) && accessibilityID('foo'))\n"
                              @"\n"
                              @"UI Hierarchy";
  XCTAssertTrue([_handler.details containsString:expectedDetails]);
}
```