### PR TITLE
Timeout Error Formatting

### DIFF
--- a/AppFramework/Core/GREYElementInteraction.m
+++ b/AppFramework/Core/GREYElementInteraction.m
@@ -527,7 +527,7 @@
     if (([errorDomain isEqualToString:kGREYInteractionErrorDomain]) &&
         (errorCode == kGREYInteractionTimeoutErrorCode)) {
       errorDetails[kErrorDetailActionNameKey] = action.name;
-      errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element";
+      errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element.";
       errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
       NSArray *keyOrder = @[
         kErrorDetailActionNameKey, kErrorDetailElementMatcherKey, kErrorDetailRecoverySuggestionKey
@@ -689,7 +689,7 @@
     if (([errorDomain isEqualToString:kGREYInteractionErrorDomain]) &&
         (errorCode == kGREYInteractionTimeoutErrorCode)) {
       errorDetails[kErrorDetailAssertCriteriaKey] = assertion.name;
-      errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element";
+      errorDetails[kErrorDetailRecoverySuggestionKey] = @"Increase timeout for matching element.";
       errorDetails[kErrorDetailElementMatcherKey] = _elementMatcher.description;
       NSArray *keyOrder = @[
         kErrorDetailAssertCriteriaKey, kErrorDetailElementMatcherKey,

--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -57,7 +57,8 @@ static NSString *const kErrorPrefix = @"EarlGrey Encountered an Error:";
 
 BOOL GREYShouldUseErrorFormatterForError(GREYError *error) {
   return [error.domain isEqualToString:kGREYInteractionErrorDomain] &&
-         error.code == kGREYInteractionElementNotFoundErrorCode;
+         (error.code == kGREYInteractionElementNotFoundErrorCode ||
+          error.code == kGREYInteractionTimeoutErrorCode);
 }
 
 BOOL GREYShouldUseErrorFormatterForDetails(NSString *failureHandlerDetails) {


### PR DESCRIPTION
This change tracks the formatting of kGREYInteractionTimeoutErrorCode

Consider this code, which results in an interaction timeout failure:
```
  [self openTestViewNamed:@"Scroll Views"];
  id<GREYMatcher> matcher = grey_allOf(grey_accessibilityLabel(@"Label 2"), grey_interactable(), grey_sufficientlyVisible(), nil);
  [[GREYConfiguration sharedConfiguration] setValue:@(1) forConfigKey:kGREYConfigKeyInteractionTimeoutDuration];
  [[[EarlGrey selectElementWithMatcher:matcher] usingSearchAction:grey_scrollInDirection(kGREYDirectionDown, 50) onElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")] assertWithMatcher:grey_sufficientlyVisible() error:nil];
```

Avg Execution Time, before: 5.4s
Avg Execution Time, after: 5.3 s

Console Output, before:
```
Exception Name: com.google.earlgrey.ElementInteractionErrorDomain
Exception Reason: Interaction timed out after 1 seconds while searching for element.
Exception Details: Matching element timed out.
Exception with Assertion: {
  "Assertion Criteria" : "assertWithMatcher:sufficientlyVisible(Expected: 0.750000, Actual: 0.000000)",
  "Element Matcher" : "(((respondsToSelector(isAccessibilityElement) && isAccessibilityElement) && accessibilityLabel('Label 2')) && interactable Point:{nan, nan} && sufficientlyVisible(Expected: 0.750000, Actual: 0.000000))",
  "Recovery Suggestion" : "Increase timeout for matching element"
}

Screenshots: ...

UI Hierarchy: ...

Stack Trace: ...
```

Console Output, after:
```
EarlGrey Encountered an Error:

Interaction timed out after 1 seconds while searching for element.

Increase timeout for matching element.

Element Matcher:
(((respondsToSelector(isAccessibilityElement) && isAccessibilityElement) && accessibilityLabel('Label 2')) && interactable Point:{nan, nan} && sufficientlyVisible(Expected: 0.750000, Actual: 0.000000))

Assertion Criteria: assertWithMatcher:sufficientlyVisible(Expected: 0.750000, Actual: 0.000000)

Screenshots: ...

UI Hierarchy: ...

Stack Trace: ...
```

Note that "EarlGrey Encountered an Error:" is temporary, until all error codes are using GREYErrorFormatter.


A new test should be added internally into the failure formatting test:
```
- (void)testTimeoutErrorDescription {
  [self openTestViewNamed:@"Scroll Views"];
  id<GREYMatcher> matcher = grey_allOf(grey_accessibilityLabel(@"Label 2"), grey_interactable(),
                                       grey_sufficientlyVisible(), nil);
  [[GREYConfiguration sharedConfiguration] setValue:@(1)
                                       forConfigKey:kGREYConfigKeyInteractionTimeoutDuration];
  [[[EarlGrey selectElementWithMatcher:matcher]
         usingSearchAction:grey_scrollInDirection(kGREYDirectionDown, 50)
      onElementWithMatcher:grey_accessibilityLabel(@"Upper Scroll View")]
      assertWithMatcher:grey_sufficientlyVisible()
                  error:nil];
  NSString *expectedDetails = @"Interaction timed out after 1 seconds while searching "
                              @"for element.\n"
                              @"\n"
                              @"Increase timeout for matching element.\n"
                              @"\n"
                              @"Element Matcher:\n"
                              @"(((respondsToSelector(isAccessibilityElement) && "
                              @"isAccessibilityElement) && accessibilityLabel('Label 2')) && "
                              @"interactable Point:{nan, nan} && sufficientlyVisible(Expected: "
                              @"0.750000, Actual: 0.000000))\n"
                              @"\n"
                              @"Assertion Criteria: assertWithMatcher:sufficientlyVisible(E"
                              @"xpected: 0.750000, Actual: 0.000000)\n"
                              @"\n"
                              @"UI Hierarchy";
  XCTAssertTrue([_handler.details containsString:expectedDetails]);
}
```