### PR TITLE
Constraints Failed Error Format

### DIFF
--- a/AppFramework/Action/GREYBaseAction.m
+++ b/AppFramework/Action/GREYBaseAction.m
@@ -66,7 +66,6 @@
       errorDetails[kErrorDetailActionNameKey] = _name;
       errorDetails[kErrorDetailElementDescriptionKey] = description;
       errorDetails[kErrorDetailConstraintRequirementKey] = mismatchDetail;
-      errorDetails[kErrorDetailConstraintDetailsKey] = [_constraints description];
       errorDetails[kErrorDetailRecoverySuggestionKey] =
           @"Adjust element properties so that it matches the failed constraint(s).";
 

--- a/AppFramework/Core/GREYElementInteraction.m
+++ b/AppFramework/Core/GREYElementInteraction.m
@@ -823,8 +823,10 @@
   if ([interactionError respondsToSelector:@selector(nestedError)]) {
     [userInfo setValue:interactionError.nestedError forKey:NSUnderlyingErrorKey];
   }
-  [userInfo setValue:_elementMatcher.description forKey:kErrorDetailElementMatcherKey];
-
+  if ([interactionError isKindOfClass:[GREYError class]] &&
+      interactionError.code != kGREYInteractionConstraintsFailedErrorCode) {
+    [userInfo setValue:_elementMatcher.description forKey:kErrorDetailElementMatcherKey];
+  }
   NSDictionary<NSString *, UIImage *> *appScreenshots =
       [self grey_appScreenshotsFromError:interactionError];
 

--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -114,12 +114,12 @@ static NSString *LoggerDescription(GREYError *error) {
 
   NSString *failedConstraints = error.userInfo[kErrorDetailConstraintRequirementKey];
   if (failedConstraints) {
-    [logger appendFormat:@"%@:\n%@", kErrorDetailConstraintRequirementKey, failedConstraints];
+    [logger appendFormat:@"\n\n%@:\n%@", kErrorDetailConstraintRequirementKey, failedConstraints];
   }
   
   NSString *elementDescription = error.userInfo[kErrorDetailElementDescriptionKey];
   if (elementDescription) {
-    [logger appendFormat:@"%@:\n%@", kErrorDetailElementDescriptionKey, elementDescription];
+    [logger appendFormat:@"\n\n%@:\n%@", kErrorDetailElementDescriptionKey, elementDescription];
   }
   
   NSString *assertionCriteria = error.userInfo[kErrorDetailAssertCriteriaKey];

--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -57,7 +57,8 @@ static NSString *const kErrorPrefix = @"EarlGrey Encountered an Error:";
 
 BOOL GREYShouldUseErrorFormatterForError(GREYError *error) {
   return [error.domain isEqualToString:kGREYInteractionErrorDomain] &&
-         error.code == kGREYInteractionElementNotFoundErrorCode;
+         (error.code == kGREYInteractionElementNotFoundErrorCode ||
+          error.code == kGREYInteractionConstraintsFailedErrorCode);
 }
 
 BOOL GREYShouldUseErrorFormatterForDetails(NSString *failureHandlerDetails) {
@@ -111,10 +112,21 @@ static NSString *LoggerDescription(GREYError *error) {
     [logger appendFormat:@"\n\n%@:\n%@", kErrorDetailElementMatcherKey, elementMatcher];
   }
 
+  NSString *failedConstraints = error.userInfo[kErrorDetailConstraintRequirementKey];
+  if (failedConstraints) {
+    [logger appendFormat:@"%@:\n%@", kErrorDetailConstraintRequirementKey, failedConstraints];
+  }
+  
+  NSString *elementDescription = error.userInfo[kErrorDetailElementDescriptionKey];
+  if (elementDescription) {
+    [logger appendFormat:@"%@:\n%@", kErrorDetailElementDescriptionKey, elementDescription];
+  }
+  
   NSString *assertionCriteria = error.userInfo[kErrorDetailAssertCriteriaKey];
   if (assertionCriteria) {
     [logger appendFormat:@"\n\n%@: %@", kErrorDetailAssertCriteriaKey, assertionCriteria];
   }
+  
   NSString *actionCriteria = error.userInfo[kErrorDetailActionNameKey];
   if (actionCriteria) {
     [logger appendFormat:@"\n\n%@: %@", kErrorDetailActionNameKey, actionCriteria];


### PR DESCRIPTION
This change tracks the formatting of kGREYInteractionConstraintsFailedErrorCode

Consider this code, which results in a constraints failure:
```
  [[EarlGrey selectElementWithMatcher:grey_text(@"Basic Views")] performAction:grey_tap()];
  [[EarlGrey selectElementWithMatcher:grey_buttonTitle(@"Disabled")] performAction:grey_scrollInDirection(kGREYDirectionUp, 20) error:nil];
```

Avg Execution Time, before: 4.8 s
Avg Execution Time, after: 4.9 s

Console Output, before:
```
Exception: com.google.earlgrey.ElementInteractionErrorDomain

Exception Name: com.google.earlgrey.ElementInteractionErrorDomain
Exception Reason: Cannot perform action due to constraint(s) failure.
Exception Details: Cannot perform action due to constraint(s) failure.
Exception with Action: {
  "Action Name" : "Scroll Up for 20",
  "Element Description" : "<UIButton:0x7fb32d53cf00; isAccessible=Y; AX.label='Disabled'; AX.frame={{162, 103}, {138, 30}}; AX.activationPoint={231, 118}; AX.traits='UIAccessibilityTraitButton,UIAccessibilityTraitNotEnabled'; AX.focused='N'; frame={{162, 15}, {138, 30}}; alpha=1; disabled>",
  "Failed Constraint(s)" : "kindOfClass('UIScrollView')kindOfClass('WKWebView'), ",
  "All Constraint(s)" : "((kindOfClass('UIScrollView') || kindOfClass('WKWebView')) && !(isSystemAlertViewShown))",
  "Recovery Suggestion" : "Adjust element properties so that it matches the failed constraint(s)."
}

Screenshots: ...

UI Hierarchy: ...

Stack Trace: ...
```

Console Output, after:
```
EarlGrey Encountered an Error:

Cannot perform action due to constraint(s) failure.

Adjust element properties so that it matches the failed constraint(s).

Failed Constraint(s):
kindOfClass('UIScrollView')kindOfClass('WKWebView'), 

Element Description:
<UIButton:0x7fe78c63c9a0; isAccessible=Y; AX.label='Disabled'; AX.frame={{162, 103}, {138, 30}}; AX.activationPoint={231, 118}; AX.traits='UIAccessibilityTraitButton,UIAccessibilityTraitNotEnabled'; AX.focused='N'; frame={{162, 15}, {138, 30}}; alpha=1; disabled>

Action Name: Scroll Up for 20

UI Hierarchy: ...

Screenshots: ...

Stack Trace: ...
```

Note that "EarlGrey Encountered an Error:" is temporary, until all error codes are using GREYErrorFormatter.

A new test should be added internally to the FailureFormattingTest:
```
- (void)testConstraintsFailureErrorDescription {
  [[EarlGrey selectElementWithMatcher:grey_text(@"Basic Views")] performAction:grey_tap()];
  [[EarlGrey selectElementWithMatcher:grey_buttonTitle(@"Disabled")]
      performAction:grey_scrollInDirection(kGREYDirectionUp, 20)
              error:nil];
  NSString *expectedDetails1 = @"Cannot perform action due to constraint(s) failure.\n"
                               @"\n"
                               @"Adjust element properties so that it matches the failed "
                               @"constraint(s).\n"
                               @"\n"
                               @"Failed Constraint(s):\n"
                               @"kindOfClass('UIScrollView')kindOfClass('WKWebView'), \n"
                               @"\n"
                               @"Element Description:\n"
                               @"<UIButton:";
  NSString *expectedDetails2 = @"Action Name: Scroll Up for 20\n"
                               @"\n"
                               @"UI Hierarchy";
  XCTAssertTrue([_handler.details containsString:expectedDetails1]);
  XCTAssertTrue([_handler.details containsString:expectedDetails2]);
}
```