### PR TITLE
assertion-failed-error-format

### DIFF
--- a/AppFramework/Assertion/GREYAssertions.m
+++ b/AppFramework/Assertion/GREYAssertions.m
@@ -50,7 +50,7 @@
       } else {
         NSString *reason =
             [NSString stringWithFormat:@"Element does not meet assertion criteria: "
-                                       @"%@ \nElement: %@ \nMismatch: %@ \n",
+                                       @"%@\n\nElement: %@\n\nMismatch: %@",
                                        [matcher description], [element grey_description],
                                        [mismatch description]];
         I_GREYPopulateError(errorOrNil, kGREYInteractionErrorDomain,

--- a/CommonLib/Error/GREYErrorFormatter.m
+++ b/CommonLib/Error/GREYErrorFormatter.m
@@ -57,7 +57,8 @@ static NSString *const kErrorPrefix = @"EarlGrey Encountered an Error:";
 
 BOOL GREYShouldUseErrorFormatterForError(GREYError *error) {
   return [error.domain isEqualToString:kGREYInteractionErrorDomain] &&
-         error.code == kGREYInteractionElementNotFoundErrorCode;
+         (error.code == kGREYInteractionElementNotFoundErrorCode ||
+          error.code == kGREYInteractionAssertionFailedErrorCode);
 }
 
 BOOL GREYShouldUseErrorFormatterForDetails(NSString *failureHandlerDetails) {


### PR DESCRIPTION
### This change tracks the formatting of kGREYInteractionAssertionFailedErrorCode.

### Before & After Example
Consider this code, which results in an error:
```
[[EarlGrey selectElementWithMatcher:grey_keyWindow()] assertWithMatcher:grey_nil() error:nil];
```

Execution Time Before: 4.7 s
Execution Time After: 4.7 s

### Console Output, Before:
```
Exception Name: com.google.earlgrey.ElementInteractionErrorDomain
Exception Reason: Assertion with [Matcher] failed: UI [Element] failed to match the following matcher(s): [Mismatch]
Element Matcher: An assertion failed.
Exception with Assertion: {
  "Assertion Criteria" : "assertWithMatcher:isNil",
  "Element Matcher" : "(kindOfClass('UIWindow') && keyWindow)"
}

Bundle ID: com.google.com.Functional.xctrunner

Stack Trace: ...

Screenshots: {
  "App-side Screenshot at Point-of-Failure" : ....
}

UI Hierarchy (ordered by window level, back to front): ...
```

### Console Output, After:
```
EarlGrey Encountered an Error:

Element does not meet assertion criteria: isNil 

Element: <UIWindow:0x7f7fac711270; isAccessible=N; AX.frame={{0, 0}, {375, 812}}; AX.activationPoint={187.5, 406}; AX.traits='UIAccessibilityTraitNone'; AX.focused='N'; frame={{0, 0}, {375, 812}}; opaque; alpha=1>

Mismatch: isNil

Element Matcher: 
(kindOfClass('UIWindow') && keyWindow)

UI Hierarchy (ordered by window level, back to front): ...

App-side Screenshot at Point-of-Failure: ...

Stack Trace: ...
```

Note that "EarlGrey Encountered an Error:" is temporary, until all error codes are using GREYErrorFormatter.

### A new test should be added internally to the FailureFormattingTest:
```
- (void)testAssertionFailureDescription {
  [[EarlGrey selectElementWithMatcher:grey_keyWindow()] assertWithMatcher:grey_nil() error:nil];
  NSString *expectedDetails1 = @"Element does not meet assertion criteria: isNil\n"
                               @"\n"
                               @"Element: <UIWindow:";
  NSString *expectedDetails2 = @"Mismatch: isNil\n"
                               @"\n"
                               @"Element Matcher:\n"
                               @"(kindOfClass('UIWindow') && keyWindow)";
  XCTAssertTrue([_handler.details containsString:expectedDetails1]);
  XCTAssertTrue([_handler.details containsString:expectedDetails2]);
}
```