### PR TITLE
Fixing a comment that throws build error on Xcode 12

### DIFF
--- a/EarlGrey/Action/GREYActions.h
+++ b/EarlGrey/Action/GREYActions.h
@@ -317,7 +317,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param text The text to be typed. For Objective-C, backspace is supported by using "\b" in the
  *              string and "\u{8}" in Swift strings. Return key is supported with "\n".
- *              For Example: @"Helpo\b\bloWorld" will type HelloWorld in Objective-C.
+ *              For Example: @"Helpo\\b\\bloWorld" will type HelloWorld in Objective-C.
  *                           "Helpo\u{8}\u{8}loWorld" will type HelloWorld in Swift.
  *
  *  @return A GREYAction to type a specific text string in a text field.


### PR DESCRIPTION
EarlGrey module fails to build with the error...
```
While building module 'EarlGrey' imported from <user_dir>/mntf-ios/mntf/EGA/Additions/UIApplication-MNTFAdditions.m:7:
In file included from <module-includes>:1:
In file included from <user_dir>/Pods/EarlGrey/EarlGrey/EarlGrey.framework/Headers/EarlGrey.h:36:
<user_dir>/Pods/EarlGrey/EarlGrey/EarlGrey.framework/Headers/GREYActions.h:320:39: error: '\b' command does not have a valid word argument [-Werror,-Wdocumentation]
 *              For Example: @"Helpo\b\bloWorld" will type HelloWorld in Objective-C.
                                    ~~^
1 error generated.
<user_dir>/mntf-ios/mntf/EGA/Additions/UIApplication-MNTFAdditions.m:7:9: fatal error: could not build module 'EarlGrey'
#import <EarlGrey/EarlGrey.h>
 ~~~~~~~^
2 errors generated.
```

This should fix the error reported in https://github.com/google/EarlGrey/issues/1461 for Xcode 12.0 and above.

**Note:** I already signed Google Individual CLA. 

\cc @chenxiao0228 @cavecafe