### PR TITLE
Expose GREYElementHierarchy.h for CocoaPods installations

### DIFF
--- a/EarlGreyTest.podspec
+++ b/EarlGreyTest.podspec
@@ -71,6 +71,7 @@ Pod::Spec.new do |s|
                   "TestLib/Assertion/GREYWaitFunctions.h",
                   "TestLib/Condition/GREYCondition.h",
                   "TestLib/EarlGreyImpl/EarlGrey.h",
+		 "UILib/GREYElementHierarchy.h",
         ]
 
   s.source_files = test_sources


### PR DESCRIPTION
GREYElementHierarchy.h is currently not being included as a public header file on CocoaPods installations. As a consequence, it is not possible to access/print the view hierarchy of a particular screen during the UI test executions.

The purpose of this PR is to address this issue and expose GREYElementHierarchy.h for its use on the tests.