### PR TITLE
Added links to the `white-boxing-setup-guide.md` file from the `objective-c-white-boxing.md` and `swift-white-boxing.md` files

### DIFF
--- a/docs/objective-c-white-boxing.md
+++ b/docs/objective-c-white-boxing.md
@@ -1,10 +1,11 @@
 # How to Query / Modify the Application Under Test (White-Boxing) in Objective-C
 
-In Objective-C, using the Helper Bundle is quite straightforward. As mentioned,
-you just need to have categories for the Distant Objects which proxy calls from
-the tests to the application. For Objective-C, the categories must be part of
-the application, with the headers exposed to the tests. This is achieved with
-the Helper Bundle.
+In Objective-C, using the Helper Bundle defined in
+the [White-Boxing Setup Guide](white-boxing-setup-guide.md) is quite straightforward.
+As mentioned in that guide, you just need to have categories for the Distant Objects
+which proxy calls from the tests to the application. For Objective-C, the categories
+must be part of the application, with the headers exposed to the tests. This is
+achieved with the Helper Bundle.
 
 If the Helper Bundle was set up as mentioned, on running the test, it will now
 be embedded into the application under test. Please add the `User Header Search

--- a/docs/swift-white-boxing.md
+++ b/docs/swift-white-boxing.md
@@ -8,10 +8,12 @@ GREYHostApplicationDistantObject and GREYHostBackgroundDistantObject, however
 since we need to provide the test with the function declarations, we need to
 create a protocol that will help expose them.
 
-Since the Bundle is initially empty, add a Swift file into it. The file can
-be blank for now. This should automatically enable you to add a Bridging
-Header similar to the [Setup's Swift Section](setup.md#bridging_header),
-add a Bridging Header with imports for any EarlGrey files that you need.
+Since the Helper Bundle defined in
+the [White-Boxing Setup Guide](white-boxing-setup-guide.md) is initially empty,
+add a Swift file into it. The file can be blank for now.
+This should automatically enable you to add a Bridging Header as described in
+the Setup Guide's [Bridging Header](setup.md#bridging_header) section.
+Add a Bridging Header with imports for any EarlGrey files that you need.
 Refer to the [EarlGrey TestRig Bridging Header](../Tests/TestRig/Sources/Swift/SwiftTestRigBridgingHeader.h)
 for an example. The Helper Bundle runs in the app side, so **do not add any
 TestLib or any test-specific dependencies**.


### PR DESCRIPTION
Added links to the `white-boxing-setup-guide.md` file from the `objective-c-white-boxing.md` and `swift-white-boxing.md` files so that it's clearer what is meant by "Helper Bundle" to somebody who stumbles across the `objective-c-white-boxing.md` or `swift-white-boxing.md` file before they find the `white-boxing-setup-guide.md` file.