### PR TITLE
Fixing "Variable 'success' set but not used" error

### DIFF
--- a/AppFramework/DistantObject/GREYHostApplicationDistantObject.m
+++ b/AppFramework/DistantObject/GREYHostApplicationDistantObject.m
@@ -84,7 +84,7 @@ static void InitiateCommunicationWithTest() {
     NSBundle *mainBundle = [NSBundle mainBundle];
     NSArray<NSString *> *bundlePaths =
         [mainBundle pathsForResourcesOfType:@"bundle" inDirectory:@"EarlGreyHelperBundles"];
-    BOOL success = NO;
+    __unused BOOL success = NO;
     NSError *error;
     for (NSString *bundlePath in bundlePaths) {
       NSBundle *bundle = [NSBundle bundleWithPath:bundlePath];


### PR DESCRIPTION
I don't fully understand why this one was not breaking at some point but `errorString` was.