### PR TITLE
Expose enableFastAnimation for CocoaPods integration

### DIFF
--- a/EarlGreyTest.podspec
+++ b/EarlGreyTest.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
                   "AppFramework/Core/GREYInteraction.h",
                   "AppFramework/Core/GREYInteractionDataSource.h",
                   "AppFramework/DistantObject/GREYHostBackgroundDistantObject+GREYApp.h",
+                  "AppFramework/DistantObject/GREYHostApplicationDistantObject+GREYTestHelper.h",
                   "AppFramework/IdlingResources/GREYIdlingResource.h",
                   "AppFramework/Matcher/GREYAllOf.h",
                   "AppFramework/Matcher/GREYAnyOf.h",


### PR DESCRIPTION
With CocoaPods white-box testing setup, `enableFastAnimation` is not exposed to be called, which made it impossible to speed up tests.
This PR add the missing `GREYTestHelper` category header into the public header list in podspec.