### PR TITLE
Support viewForRow in grey_pickerColumnSetToValue matcher

### DIFF
--- a/AppFramework/Matcher/GREYMatchers.m
+++ b/AppFramework/Matcher/GREYMatchers.m
@@ -23,6 +23,7 @@
 #include <tgmath.h>
 
 #import "UISwitch+GREYApp.h"
+#import "UIView+GREYApp.h"
 #import "GREYElementFinder.h"
 #import "GREYAllOf+Private.h"
 #import "GREYAllOf.h"
@@ -607,6 +608,7 @@ static Class gEDOObjectClass;
     id<UIPickerViewDelegate> delegate = element.delegate;
     SEL attributedTitleSelector = @selector(pickerView:attributedTitleForRow:forComponent:);
     SEL nonAttributedTitleSelector = @selector(pickerView:titleForRow:forComponent:);
+    SEL viewForRowSelector = @selector(pickerView:viewForRow:forComponent:reusingView:);
     if ([delegate respondsToSelector:attributedTitleSelector]) {
       attributedRowLabel = [delegate pickerView:element
                           attributedTitleForRow:row
@@ -616,6 +618,18 @@ static Class gEDOObjectClass;
       }
     } else if ([delegate respondsToSelector:nonAttributedTitleSelector]) {
       rowLabel = [delegate pickerView:element titleForRow:row forComponent:column];
+    } else if ([delegate respondsToSelector:viewForRowSelector]) {
+      UIView *rowView = [delegate pickerView:element
+                                  viewForRow:row
+                                  forComponent:column
+                                  reusingView:nil];
+      if (![rowView isKindOfClass:[UILabel class]]) {
+        NSArray<UILabel *> *labels = [rowView grey_childrenAssignableFromClass:[UILabel class]];
+        UILabel *label = (labels.count > 0 ? labels[0] : nil);
+        rowLabel = label.text;
+      } else {
+        rowLabel = [((UILabel *)rowView) text];
+      }
     }
     return rowLabel == value || [rowLabel isEqualToString:value] ||
            [attributedRowLabel.string isEqualToString:value];

--- a/Tests/TestRig/Sources/PickerViewController.m
+++ b/Tests/TestRig/Sources/PickerViewController.m
@@ -58,15 +58,14 @@
   UILabel *columnView =
       [[UILabel alloc] initWithFrame:CGRectMake(35, 0, pickerView.frame.size.width / 2,
                                                 pickerView.frame.size.height)];
-  columnView.text = [self pickerView:pickerView titleForRow:row forComponent:component];
+  columnView.text = [self titleForRow:row forComponent:component];
   columnView.textAlignment = NSTextAlignmentCenter;
 
   return columnView;
 }
 
-- (NSString *)pickerView:(UIPickerView *)pickerView
-             titleForRow:(NSInteger)row
-            forComponent:(NSInteger)component {
+- (NSString *)titleForRow:(NSInteger)row
+             forComponent:(NSInteger)component {
   switch (component) {
     case 0:
       return self.customColumn1Array[(NSUInteger)row];


### PR DESCRIPTION
Matcher `grey_pickerColumnSetToValue` works fine for UIPicker with delegate that implements 
* `pickerView:titleForRow:forComponent` OR
* `pickerView:attributedTitleForRow:forComponent` 

but currently does not work for `pickerView:viewForRow:forComponent:reusingView:`

I believe it should work with viewForRow, because GREYPickerAction works fine with it and there even test that checks it – `PickerViewInteractionTest.testViewForRowDefined`. 

Unfortunately, I think that this test is broken: corresponding `PickerViewController` implements both delegate methods – `pickerView:titleForRow:forComponent` AND `pickerView:viewForRow:forComponent:reusingView:`, that why test pass.

So, I added support for viewForRow in `grey_pickerColumnSetToValue` matcher, its just copy-paste from `GREYPickerAction` and updated test code.

