### PR TITLE
iOS17 support for keyboard accessory and input views.

### DIFF
--- a/AppFramework/Keyboard/GREYKeyboard.h
+++ b/AppFramework/Keyboard/GREYKeyboard.h
@@ -40,6 +40,11 @@ NS_ASSUME_NONNULL_BEGIN
                error:(__strong NSError **)errorOrNil;
 
 /**
+ *  @return @c YES if the keyboard is visible, @c NO otherwise.
+ */
++ (BOOL)isKeyboardVisible;
+
+/**
  * Waits until the keyboard is visible on the screen.
  *
  * @return @c YES if the keyboard did appear after the wait, @c NO otherwise.

--- a/AppFramework/Keyboard/GREYKeyboard.m
+++ b/AppFramework/Keyboard/GREYKeyboard.m
@@ -283,6 +283,10 @@ __attribute__((constructor)) static void GREYSetupKeyboard(void) {
   return YES;
 }
 
++ (BOOL)isKeyboardVisible {
+  return atomic_load(&gIsKeyboardShown);
+}
+
 + (BOOL)waitForKeyboardToAppear {
   if (atomic_load(&gIsKeyboardShown)) {
     return YES;

--- a/UILib/GREYScreenshotter.m
+++ b/UILib/GREYScreenshotter.m
@@ -150,10 +150,11 @@ static UIScreen *MainScreen(void) {
   // The bitmap context width and height are scaled, so we need to undo the scale adjustment.
   NSEnumerator *allWindowsInReverse =
       [[GREYUIWindowProvider allWindowsWithStatusBar:includeStatusBar] reverseObjectEnumerator];
+  CGFloat maxLevel = [GREYKeyboard isKeyboardVisible] ? 1 : 0;
   for (UIWindow *window in allWindowsInReverse) {
     if (window.hidden || window.alpha == 0 ||
         (iOS17_OR_ABOVE() && [window respondsToSelector:@selector(windowLevel)] &&
-         window.windowLevel > 0)) {
+         window.windowLevel > maxLevel)) {
       continue;
     }
     [self drawViewInContext:bitmapContextRef

--- a/UILib/Provider/GREYUIWindowProvider.m
+++ b/UILib/Provider/GREYUIWindowProvider.m
@@ -106,6 +106,9 @@ static UIView *GetFirstResponderSubview(UIView *view) {
     UIResponder *firstResponder = GetFirstResponderSubview(keyWindow);
     UIView *inputView = firstResponder.inputView;
     if (inputView.window) {
+      if (@available(iOS 17, *)) {
+        inputView.window.windowLevel = 1;
+      }
       [windows addObject:inputView.window];
     }
     UIWindow *keyboardWindow = GREYUILibUtilsGetKeyboardWindow();


### PR DESCRIPTION
When the keyboard is visible, allow windowLevel 1, and when an inputView is found, set the windowLevel to 1, instead of negative int max.

A better fix might look at the window before trusting window level, and maybe just fix the sort instead of resetting windowLevel on the inputView.