### PR TITLE
Tag `-selectElementWithMatcher:` with `NS_WARN_UNUSED_RESULT`

### DIFF
--- a/EarlGrey/Core/EarlGreyImpl.h
+++ b/EarlGrey/Core/EarlGreyImpl.h
@@ -106,7 +106,7 @@ typedef NS_ENUM(NSInteger, GREYKeyboardDismissalErrorCode) {
  *
  *  @return A GREYElementInteraction instance, initialized with an appropriate matcher.
  */
-- (GREYElementInteraction *)selectElementWithMatcher:(id<GREYMatcher>)elementMatcher;
+- (GREYElementInteraction *)selectElementWithMatcher:(id<GREYMatcher>)elementMatcher NS_WARN_UNUSED_RESULT;
 
 /**
  *  Sets the global failure handler for all framework related failures.


### PR DESCRIPTION
We often run into a human error, when an element is selected by not asserted on or acted upon. With the unused result attribute, the person writing a test would get a nag that no action was performed on the element.