### PR TITLE
Introduce rotateLayoutToOrientation:error:

### DIFF
--- a/TestLib/EarlGreyImpl/EarlGreyImpl.h
+++ b/TestLib/EarlGreyImpl/EarlGreyImpl.h
@@ -275,7 +275,7 @@ typedef void (^GREYHostApplicationCrashHandler)(void);
  * be populated with the failure reason if the orientation change fails, otherwise a test failure
  * will be registered.
  *
- * @param      deviceOrientation The desired orientation of the device.
+ * @param      layoutOrientation The desired orientation of the layout.
  * @param[out] error             Error that will be populated on failure. If @c nil, the a test
  *                               failure will be reported if the rotation attempt fails.
  *
@@ -283,6 +283,12 @@ typedef void (^GREYHostApplicationCrashHandler)(void);
  *
  * @return @c YES if the rotation was successful, @c NO otherwise. If @c error is @c nil and
  *         the operation fails, it will throw an exception.
+ */
+- (BOOL)rotateLayoutToOrientation:(UILayoutOrientation)layoutOrientation error:(NSError **)error;
+
+/**
+ * Same as @c -[rotateLayoutToOrientation:error:]` but deprecated. Device orientation face up and face down are treated similarly to unknown.
+ * 
  */
 - (BOOL)rotateDeviceToOrientation:(UIDeviceOrientation)deviceOrientation error:(NSError **)error;
 

--- a/TestLib/EarlGreyImpl/EarlGreyImpl.m
+++ b/TestLib/EarlGreyImpl/EarlGreyImpl.m
@@ -272,7 +272,11 @@ static BOOL ExecuteSyncBlockInBackgroundQueue(BOOL (^block)(void)) {
   XCUIDevice *sharedDevice = [XCUIDevice sharedDevice];
   UIDevice *currentDevice = [GREY_REMOTE_CLASS_IN_APP(UIDevice) currentDevice];
   UIInterfaceOrientation interfaceOrientation =
-      [GREYConstants interfaceOrientationForDeviceOrientation:deviceOrientation];
+  [GREYConstants interfaceOrientationForDeviceOrientation:deviceOrientation];
+  return [self rotateLayoutToOrientation:interfaceOrientation error:error];
+}
+
+- (BOOL)rotateLayoutToOrientation:(UILayoutOrientation)deviceOrientation error:(NSError **)error {
   if (interfaceOrientation != UIInterfaceOrientationUnknown) {
 
     NSNotificationCenter *notificationCenter =


### PR DESCRIPTION
The problem with rotateDeviceToOrientation:error: is that actually only the layout is rotated, not the device. The method can’t fully simulate device rotation because it can not consider rotating to face up or down. By restricting the rotation to layout, it ensures that all possible non-unknown entries are valid entries.

Fixes #2111