### PR TITLE
Define rotateDeviceToOrientation using rotateInterfaceToOrientation

### DIFF
--- a/TestLib/EarlGreyImpl/EarlGreyImpl.m
+++ b/TestLib/EarlGreyImpl/EarlGreyImpl.m
@@ -265,22 +265,21 @@ static BOOL ExecuteSyncBlockInBackgroundQueue(BOOL (^block)(void)) {
 
 #if TARGET_OS_IOS
 
-- (BOOL)rotateInterfaceToOrientation:(UIInterfaceOrientation)interfaceOrientation
-                               error:(NSError **)error {
-  UIDeviceOrientation deviceOrientation =
-      [GREYConstants deviceOrientationForInterfaceOrientation:interfaceOrientation];
-  return [self rotateDeviceToOrientation:deviceOrientation error:error];
+- (BOOL)rotateDeviceToOrientation:(UIDeviceOrientation)deviceOrientation
+                            error:(NSError **)error {
+  UIInterfaceOrientation interfaceOrientation =
+      [GREYConstants interfaceOrientationForDeviceOrientation:deviceOrientation];
+  return [self rotateInterfaceToOrientation:interfaceOrientation error:error];
 }
 
-- (BOOL)rotateDeviceToOrientation:(UIDeviceOrientation)deviceOrientation error:(NSError **)error {
+- (BOOL)rotateInterfaceToOrientation:(UIInterfaceOrientation)interfaceOrientation
+                               error:(NSError **)error {
   GREYError *syncErrorBeforeRotation;
   __block GREYError *syncErrorAfterRotation;
   BOOL success = NO;
   __block BOOL sendOrientationChangeNotification = NO;
   XCUIDevice *sharedDevice = [XCUIDevice sharedDevice];
   UIDevice *currentDevice = [GREY_REMOTE_CLASS_IN_APP(UIDevice) currentDevice];
-  UIInterfaceOrientation interfaceOrientation =
-      [GREYConstants interfaceOrientationForDeviceOrientation:deviceOrientation];
   if (interfaceOrientation != UIInterfaceOrientationUnknown) {
 
     NSNotificationCenter *notificationCenter =


### PR DESCRIPTION
This ensures that the deprecated method is not called anymore. This also avoids to transform the orientation from interface to device to interface.

Fixed #2111